### PR TITLE
Align footer Oasis of Change logo with section headings

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -417,7 +417,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/accessibility_statement.html
+++ b/public/accessibility_statement.html
@@ -339,7 +339,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/annual_reports.html
+++ b/public/annual_reports.html
@@ -333,7 +333,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/blog-example-article.html
+++ b/public/blog-example-article.html
@@ -296,7 +296,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/blog.html
+++ b/public/blog.html
@@ -350,7 +350,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/case-studies.html
+++ b/public/case-studies.html
@@ -282,7 +282,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/company.html
+++ b/public/company.html
@@ -298,7 +298,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/contact.html
+++ b/public/contact.html
@@ -314,7 +314,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/denman-place-mall.html
+++ b/public/denman-place-mall.html
@@ -469,7 +469,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/example_annual_report.html
+++ b/public/example_annual_report.html
@@ -392,7 +392,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/gabriel-dalton.html
+++ b/public/gabriel-dalton.html
@@ -317,7 +317,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/get_involved.html
+++ b/public/get_involved.html
@@ -312,7 +312,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/index.html
+++ b/public/index.html
@@ -630,7 +630,7 @@
           <div class="footer-grid">
             <div class="footer-brand">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/initiatives.html
+++ b/public/initiatives.html
@@ -351,7 +351,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/mittler-senior-technology.html
+++ b/public/mittler-senior-technology.html
@@ -821,7 +821,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/news-example-post.html
+++ b/public/news-example-post.html
@@ -360,7 +360,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/news_release.html
+++ b/public/news_release.html
@@ -379,7 +379,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/nonprofits.html
+++ b/public/nonprofits.html
@@ -423,7 +423,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/oasis-of-change-website.html
+++ b/public/oasis-of-change-website.html
@@ -451,7 +451,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/ooc-self-case-study.html
+++ b/public/ooc-self-case-study.html
@@ -741,7 +741,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -305,7 +305,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/sustainability_statement.html
+++ b/public/sustainability_statement.html
@@ -288,7 +288,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/sustainable-technology-week.html
+++ b/public/sustainable-technology-week.html
@@ -261,7 +261,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/tree_planting.html
+++ b/public/tree_planting.html
@@ -288,7 +288,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/vcasse.html
+++ b/public/vcasse.html
@@ -342,7 +342,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/web-ready.html
+++ b/public/web-ready.html
@@ -314,7 +314,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.

--- a/public/wra_platform.html
+++ b/public/wra_platform.html
@@ -380,7 +380,7 @@
           <div class="flex flex-col lg:flex-row lg:justify-between gap-12 xl:gap-16">
             <div class="w-full max-w-md shrink-0">
               <div class="mb-4">
-                <img class="h-14 sm:h-16 w-auto shrink-0" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
+                <img class="h-14 sm:h-16 w-auto shrink-0 -mt-2 mb-2" src="images/logo/Oasis_of_Change-official.svg" alt="Oasis of Change" width="64" height="64">
               </div>
               <p class="tracking-tight text-gray-200 leading-relaxed text-sm sm:text-base max-w-md">
                 Building a more sustainable digital future through energy-efficient websites, transparent impact, and technology that supports communities and the planet.


### PR DESCRIPTION
### Motivation
- The Oasis of Change footer logo block was sitting slightly lower than neighboring footer section headings (General, Initiatives, etc.), creating a visual misalignment. 
- A small upward nudge to the logo block improves horizontal alignment without structural layout changes. 
- The adjustment needed to be applied consistently to every footer instance across the static `public/` HTML files.

### Description
- Updated the footer logo `<img>` classes to add `-mt-2 mb-2` so the 64x64 `images/logo/Oasis_of_Change-official.svg` logo block sits slightly higher and aligns with adjacent section titles. 
- Targeted the footer instances where the logo is rendered (class variants like `h-14 sm:h-16 w-auto` and `h-14 sm:h-16 w-auto shrink-0`). 
- Applied the change across all affected HTML files in `public/` for consistent appearance (27 files updated).

### Testing
- Ran the replacement script which reported `27` replacements using the project Python helper, and the script completed successfully. 
- Verified the updated pattern with `rg -n "h-14 sm:h-16 w-auto[^"]*-mt-2 mb-2\" src=\"images/logo/Oasis_of_Change-official.svg\" alt=\"Oasis of Change\" width=\"64\" height=\"64\"" public/*.html | wc -l`, which returned `27`. 
- No automated visual regression screenshots were produced in this environment, but the textual matches and replacement counts confirm the change was applied consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf74ef827083209b6f0a92e9738ddf)