### PR TITLE
claude/fix-contact-page-mobile-W0EPv

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -230,7 +230,7 @@
 
       
           <!-- CONTACT PANEL -->
-          <section class="rounded-2xl border border-gray-200 bg-gray-50 px-6 md:px-10 lg:px-16 py-14 md:py-18 lg:py-20 mb-12 md:mb-16">
+          <section class="rounded-2xl border border-gray-200 bg-gray-50 px-4 sm:px-6 md:px-10 lg:px-16 pt-10 sm:pt-12 md:pt-18 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-28 mt-2 sm:mt-4 mb-12 md:mb-16">
             <div class="max-w-4xl mx-auto">
               <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-8">
                 <a href="index.html" class="hover:text-gray-900 transition">Home</a>
@@ -246,7 +246,7 @@
               </div>
 
               <!-- Contact form -->
-              <div class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 lg:p-10">
+              <div class="rounded-2xl border border-gray-200 bg-white p-4 sm:p-6 md:p-8 lg:p-10">
 
                 <form id="contact-form" action="#" method="POST" novalidate class="cf-form">
 

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -230,7 +230,7 @@
 
       
           <!-- CONTACT PANEL -->
-          <section class="rounded-2xl border border-gray-200 bg-gray-50 px-6 md:px-10 lg:px-16 py-14 md:py-18 lg:py-20 mb-12 md:mb-16">
+          <section class="rounded-2xl border border-gray-200 bg-gray-50 px-4 sm:px-6 md:px-10 lg:px-16 pt-10 sm:pt-12 md:pt-18 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-28 mt-2 sm:mt-4 mb-12 md:mb-16">
             <div class="max-w-4xl mx-auto">
               <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-8">
                 <a href="index.html" class="hover:text-gray-900 transition">Home</a>
@@ -246,7 +246,7 @@
               </div>
 
               <!-- Contact form -->
-              <div class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 lg:p-10">
+              <div class="rounded-2xl border border-gray-200 bg-white p-4 sm:p-6 md:p-8 lg:p-10">
 
                 <form id="contact-form" action="#" method="POST" novalidate class="cf-form">
 


### PR DESCRIPTION
- Reduce nested horizontal padding on mobile (px-6 → px-4 base) for both
  the contact panel and form card so the form has more breathing room on
  small screens
- Add top margin (mt-2 sm:mt-4) between the nav bar and the gray contact
  panel to match spacing on other pages
- Increase bottom padding on the gray panel (pb-16 → pb-28 responsive) so
  the background extends further below the form card

https://claude.ai/code/session_01CAQRodaQ1xryjokH6aj2cK