### PR TITLE
feat: add dynamic OG images and SEO tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 .env*.local
+node_modules/

--- a/api/og.js
+++ b/api/og.js
@@ -1,0 +1,129 @@
+import { ImageResponse } from '@vercel/og';
+
+export const config = { runtime: 'edge' };
+
+export default async function handler(req) {
+  const { searchParams } = new URL(req.url);
+  const title = searchParams.get('title') || 'Oasis of Change';
+
+  // Split long titles at the pipe separator for layout
+  const parts = title.split('|').map((s) => s.trim());
+  const pageTitle = parts[0] || '';
+  const siteName = parts[1] || 'Oasis of Change, Inc.';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '60px 72px',
+          background: 'linear-gradient(145deg, #0a0a0a 0%, #111827 50%, #064e3b 100%)',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+        }}
+      >
+        {/* Top: decorative accent */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '16px',
+          }}
+        >
+          <div
+            style={{
+              width: '48px',
+              height: '48px',
+              borderRadius: '12px',
+              background: 'linear-gradient(135deg, #22c55e, #16a34a)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                fill="white"
+              />
+            </svg>
+          </div>
+          <span
+            style={{
+              color: '#9ca3af',
+              fontSize: '22px',
+              fontWeight: 500,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            {siteName}
+          </span>
+        </div>
+
+        {/* Center: page title */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0',
+            flex: 1,
+            justifyContent: 'center',
+          }}
+        >
+          <h1
+            style={{
+              fontSize: pageTitle.length > 40 ? '52px' : '64px',
+              fontWeight: 700,
+              color: '#ffffff',
+              lineHeight: 1.15,
+              letterSpacing: '-0.03em',
+              margin: 0,
+            }}
+          >
+            {pageTitle}
+          </h1>
+        </div>
+
+        {/* Bottom: site URL + green bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span
+            style={{
+              color: '#6b7280',
+              fontSize: '20px',
+              fontWeight: 400,
+            }}
+          >
+            www.oasisofchange.com
+          </span>
+          <div
+            style={{
+              width: '120px',
+              height: '4px',
+              borderRadius: '2px',
+              background: 'linear-gradient(90deg, #22c55e, #16a34a)',
+            }}
+          />
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}

--- a/api/og.js
+++ b/api/og.js
@@ -1,20 +1,47 @@
-import { ImageResponse } from '@vercel/og';
+const satori = require('satori');
+const { Resvg } = require('@resvg/resvg-js');
 
-export const config = { runtime: 'edge' };
+// Cache the font in-memory across warm invocations
+let fontData = null;
 
-export default async function handler(req) {
-  const { searchParams } = new URL(req.url);
-  const title = searchParams.get('title') || 'Oasis of Change';
+async function loadFont() {
+  if (fontData) return fontData;
+  const res = await fetch(
+    'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap'
+  );
+  const css = await res.text();
+  // Extract the woff2 URL for latin 700
+  const urlMatch = css.match(/src:\s*url\(([^)]+)\)\s*format\('woff2'\);[^}]*unicode-range:\s*U\+0000-00FF/);
+  if (!urlMatch) throw new Error('Could not find font URL');
+  const fontRes = await fetch(urlMatch[1]);
+  fontData = await fontRes.arrayBuffer();
+  return fontData;
+}
 
-  // Split long titles at the pipe separator for layout
-  const parts = title.split('|').map((s) => s.trim());
-  const pageTitle = parts[0] || '';
-  const siteName = parts[1] || 'Oasis of Change, Inc.';
+function h(type, props, ...children) {
+  const flatChildren = children.flat().filter(Boolean);
+  return {
+    type,
+    props: {
+      ...props,
+      children: flatChildren.length === 1 ? flatChildren[0] : flatChildren.length === 0 ? undefined : flatChildren,
+    },
+  };
+}
 
-  return new ImageResponse(
-    (
-      <div
-        style={{
+module.exports = async function handler(req, res) {
+  try {
+    const title = (req.query.title || 'Oasis of Change').toString();
+    const parts = title.split('|').map((s) => s.trim());
+    const pageTitle = parts[0] || '';
+    const siteName = parts[1] || 'Oasis of Change, Inc.';
+
+    const font = await loadFont();
+
+    const markup = h(
+      'div',
+      {
+        style: {
           width: '100%',
           height: '100%',
           display: 'flex',
@@ -22,108 +49,119 @@ export default async function handler(req) {
           justifyContent: 'space-between',
           padding: '60px 72px',
           background: 'linear-gradient(145deg, #0a0a0a 0%, #111827 50%, #064e3b 100%)',
-          fontFamily: 'system-ui, -apple-system, sans-serif',
-        }}
-      >
-        {/* Top: decorative accent */}
-        <div
-          style={{
+          fontFamily: 'Inter, sans-serif',
+        },
+      },
+      // Top: icon + site name
+      h(
+        'div',
+        {
+          style: {
             display: 'flex',
             alignItems: 'center',
             gap: '16px',
-          }}
-        >
-          <div
-            style={{
-              width: '48px',
-              height: '48px',
-              borderRadius: '12px',
-              background: 'linear-gradient(135deg, #22c55e, #16a34a)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                fill="white"
-              />
-            </svg>
-          </div>
-          <span
-            style={{
-              color: '#9ca3af',
-              fontSize: '22px',
-              fontWeight: 500,
-              letterSpacing: '-0.01em',
-            }}
-          >
-            {siteName}
-          </span>
-        </div>
-
-        {/* Center: page title */}
-        <div
-          style={{
+          },
+        },
+        h('div', {
+          style: {
+            width: '48px',
+            height: '48px',
+            borderRadius: '12px',
+            background: 'linear-gradient(135deg, #22c55e, #16a34a)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white',
+            fontSize: '24px',
+            fontWeight: 700,
+          },
+        }, '\u2713'),
+        h('span', {
+          style: {
+            color: '#9ca3af',
+            fontSize: '22px',
+            fontWeight: 400,
+          },
+        }, siteName)
+      ),
+      // Center: page title
+      h(
+        'div',
+        {
+          style: {
             display: 'flex',
             flexDirection: 'column',
-            gap: '0',
             flex: 1,
             justifyContent: 'center',
-          }}
-        >
-          <h1
-            style={{
-              fontSize: pageTitle.length > 40 ? '52px' : '64px',
-              fontWeight: 700,
-              color: '#ffffff',
-              lineHeight: 1.15,
-              letterSpacing: '-0.03em',
-              margin: 0,
-            }}
-          >
-            {pageTitle}
-          </h1>
-        </div>
-
-        {/* Bottom: site URL + green bar */}
-        <div
-          style={{
+          },
+        },
+        h('div', {
+          style: {
+            fontSize: pageTitle.length > 40 ? 52 : 64,
+            fontWeight: 700,
+            color: '#ffffff',
+            lineHeight: 1.15,
+            letterSpacing: '-0.03em',
+          },
+        }, pageTitle)
+      ),
+      // Bottom: URL + accent bar
+      h(
+        'div',
+        {
+          style: {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-          }}
-        >
-          <span
-            style={{
-              color: '#6b7280',
-              fontSize: '20px',
-              fontWeight: 400,
-            }}
-          >
-            www.oasisofchange.com
-          </span>
-          <div
-            style={{
-              width: '120px',
-              height: '4px',
-              borderRadius: '2px',
-              background: 'linear-gradient(90deg, #22c55e, #16a34a)',
-            }}
-          />
-        </div>
-      </div>
-    ),
-    {
+          },
+        },
+        h('span', {
+          style: {
+            color: '#6b7280',
+            fontSize: '20px',
+            fontWeight: 400,
+          },
+        }, 'www.oasisofchange.com'),
+        h('div', {
+          style: {
+            width: '120px',
+            height: '4px',
+            borderRadius: '2px',
+            background: 'linear-gradient(90deg, #22c55e, #16a34a)',
+          },
+        })
+      )
+    );
+
+    const svg = await satori(markup, {
       width: 1200,
       height: 630,
-    }
-  );
-}
+      fonts: [
+        {
+          name: 'Inter',
+          data: Buffer.from(font),
+          weight: 400,
+          style: 'normal',
+        },
+        {
+          name: 'Inter',
+          data: Buffer.from(font),
+          weight: 700,
+          style: 'normal',
+        },
+      ],
+    });
+
+    const resvg = new Resvg(svg, {
+      fitTo: { mode: 'width', value: 1200 },
+    });
+    const png = resvg.render().asPng();
+
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800');
+    res.end(png);
+  } catch (err) {
+    console.error('OG image generation error:', err);
+    res.status(500).json({ error: 'Failed to generate image' });
+  }
+};

--- a/build.py
+++ b/build.py
@@ -5,7 +5,8 @@ Workflow:
   - Reads every src/pages/**.html
   - Resolves {{include partial-name.html}} markers by inlining src/partials/...
   - Substitutes {{base}} per page based on the page's directory depth
-    (so a page at src/pages/blog/foo.html gets base="../", root pages get base="")
+  - Loads seo-config.json and injects per-page SEO variables (title, description,
+    canonical URL, OG image, JSON-LD structured data)
   - Writes the result to public/ with the same directory structure
 
 Usage:
@@ -17,18 +18,142 @@ Add new partials by dropping files into src/partials/ and referencing them as
 """
 from pathlib import Path
 import argparse
+import html
+import json
 import re
 import shutil
 import sys
 import tempfile
+import urllib.parse
 
 ROOT = Path(__file__).resolve().parent
 SRC_PAGES = ROOT / 'src' / 'pages'
 SRC_PARTIALS = ROOT / 'src' / 'partials'
 OUT = ROOT / 'public'
+SEO_CONFIG_PATH = ROOT / 'seo-config.json'
 
 INCLUDE_RE = re.compile(r'\{\{\s*include\s+([^\s}]+)\s*\}\}')
 MAX_INCLUDE_DEPTH = 5
+
+
+def load_seo_config():
+    """Load the SEO configuration from seo-config.json."""
+    if not SEO_CONFIG_PATH.exists():
+        print(f'WARNING: {SEO_CONFIG_PATH} not found. SEO variables will be empty.',
+              file=sys.stderr)
+        return None
+    with open(SEO_CONFIG_PATH, encoding='utf-8') as f:
+        return json.load(f)
+
+
+def canonical_url_for(site_url, page_rel):
+    """Derive the canonical URL from a page's relative path."""
+    page_str = str(page_rel).replace('\\', '/')
+    if page_str == 'index.html':
+        return site_url + '/'
+    if page_str.endswith('/index.html'):
+        # e.g. blog/index.html -> /blog/
+        return site_url + '/' + page_str.replace('/index.html', '/')
+    # e.g. about.html -> /about  (Vercel cleanUrls strips .html)
+    return site_url + '/' + page_str.replace('.html', '')
+
+
+def og_image_url_for(site_url, title):
+    """Build the dynamic OG image URL for a page."""
+    encoded_title = urllib.parse.quote(title, safe='')
+    return f'{site_url}/api/og?title={encoded_title}'
+
+
+def build_jsonld(page_meta, canonical, og_image, seo_config):
+    """Generate JSON-LD structured data for a page."""
+    site_name = seo_config['site_name']
+    site_url = seo_config['site_url']
+    site_logo = seo_config['site_logo']
+
+    publisher = {
+        '@type': 'Organization',
+        'name': site_name,
+        'url': site_url,
+        'logo': {
+            '@type': 'ImageObject',
+            'url': site_logo
+        }
+    }
+
+    og_type = page_meta.get('og_type', 'website')
+
+    if og_type == 'article':
+        ld = {
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            'headline': page_meta['title'],
+            'description': page_meta['description'],
+            'url': canonical,
+            'image': og_image,
+            'publisher': publisher
+        }
+        if page_meta.get('article_author'):
+            ld['author'] = {
+                '@type': 'Person',
+                'name': page_meta['article_author']
+            }
+    else:
+        ld = {
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            'name': page_meta['title'],
+            'description': page_meta['description'],
+            'url': canonical,
+            'image': og_image,
+            'publisher': publisher
+        }
+
+    return '    <script type="application/ld+json">' + json.dumps(ld, ensure_ascii=False) + '</script>'
+
+
+def seo_vars_for(page_rel, seo_config):
+    """Build the SEO template variables for a given page."""
+    page_key = str(page_rel).replace('\\', '/')
+    if seo_config is None or page_key not in seo_config.get('pages', {}):
+        # Return empty strings so {{seo_*}} placeholders are cleared
+        return {
+            'seo_title': '',
+            'seo_description': '',
+            'seo_og_type': 'website',
+            'seo_canonical': '',
+            'seo_og_image': '',
+            'seo_extra_meta': '',
+            'seo_jsonld': '',
+        }
+
+    site_url = seo_config['site_url']
+    page_meta = seo_config['pages'][page_key]
+    title = page_meta['title']
+    description = page_meta['description']
+    og_type = page_meta.get('og_type', seo_config.get('default_og_type', 'website'))
+    canonical = canonical_url_for(site_url, page_rel)
+    og_image = og_image_url_for(site_url, title)
+
+    # Extra meta tags (article-specific)
+    extra_meta_lines = []
+    if page_meta.get('article_author'):
+        extra_meta_lines.append(
+            f'    <meta property="article:author" content="{html.escape(page_meta["article_author"])}">')
+    extra_meta = '\n'.join(extra_meta_lines)
+    if extra_meta:
+        extra_meta += '\n'
+
+    jsonld = build_jsonld(page_meta, canonical, og_image, seo_config)
+
+    return {
+        'seo_title': html.escape(title, quote=True),
+        'seo_description': html.escape(description, quote=True),
+        'seo_og_type': og_type,
+        'seo_canonical': canonical,
+        'seo_og_image': og_image,
+        'seo_extra_meta': extra_meta,
+        'seo_jsonld': jsonld,
+    }
 
 
 def base_for(page_rel_path):
@@ -64,6 +189,8 @@ def build(out_dir):
               file=sys.stderr)
         return 1
 
+    seo_config = load_seo_config()
+
     pages = sorted(p for p in SRC_PAGES.rglob('*.html') if p.is_file())
     print(f'Building {len(pages)} pages -> {out_dir}/')
     for page in pages:
@@ -71,6 +198,7 @@ def build(out_dir):
         out_path = out_dir / rel
         out_path.parent.mkdir(parents=True, exist_ok=True)
         page_vars = {'base': base_for(rel)}
+        page_vars.update(seo_vars_for(rel, seo_config))
         try:
             rendered = render(page.read_text(encoding='utf-8'), page_vars)
         except Exception as e:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,234 @@
+{
+  "name": "oasis-of-change-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oasis-of-change-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "@vercel/og": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@vercel/og": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.6.8.tgz",
+      "integrity": "sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.12.2",
+        "yoga-wasm-web": "0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
+      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/satori": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
+      "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.16",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex": "^10.2.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,224 @@
       "name": "oasis-of-change-site",
       "version": "1.0.0",
       "dependencies": {
-        "@vercel/og": "^0.6.0"
+        "@resvg/resvg-js": "^2.6.0",
+        "satori": "^0.12.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@resvg/resvg-wasm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
-      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
       "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -37,20 +244,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/@vercel/og": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.6.8.tgz",
-      "integrity": "sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@resvg/resvg-wasm": "2.4.0",
-        "satori": "0.12.2",
-        "yoga-wasm-web": "0.3.3"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/base64-js": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vercel/og": "^0.6.0"
+    "satori": "^0.12.0",
+    "@resvg/resvg-js": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "description": "Oasis of Change website — static HTML/CSS/JS with Vercel serverless functions.",
   "engines": {
     "node": ">=18"
+  },
+  "dependencies": {
+    "@vercel/og": "^0.6.0"
   }
 }

--- a/public/404.html
+++ b/public/404.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Page Not Found | Oasis of Change, Inc.</title>
-    <meta name="description" content="The page you're looking for doesn't exist or has been moved.">
+        <title>Page Not Found | Oasis of Change, Inc.</title>
+    <meta name="description" content="The page you&#x27;re looking for doesn&#x27;t exist or has been moved.">
+    <link rel="canonical" href="https://www.oasisofchange.com/404">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Page Not Found | Oasis of Change, Inc.">
-    <meta property="og:description" content="The page you're looking for doesn't exist or has been moved.">
+    <meta property="og:description" content="The page you&#x27;re looking for doesn&#x27;t exist or has been moved.">
+    <meta property="og:url" content="https://www.oasisofchange.com/404">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Page%20Not%20Found%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Page Not Found | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The page you're looking for doesn't exist or has been moved.">
+    <meta name="twitter:description" content="The page you&#x27;re looking for doesn&#x27;t exist or has been moved.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Page%20Not%20Found%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Page Not Found | Oasis of Change, Inc.", "description": "The page you're looking for doesn't exist or has been moved.", "url": "https://www.oasisofchange.com/404", "image": "https://www.oasisofchange.com/api/og?title=Page%20Not%20Found%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <meta name="robots" content="noindex, nofollow">
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">

--- a/public/about.html
+++ b/public/about.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>About | Oasis of Change, Inc.</title>
-    <meta name="description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+        <title>About | Oasis of Change, Inc.</title>
+    <meta name="description" content="Discover Oasis of Change&#x27;s mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    <link rel="canonical" href="https://www.oasisofchange.com/about">
     <meta property="og:type" content="website">
     <meta property="og:title" content="About | Oasis of Change, Inc.">
-    <meta property="og:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    <meta property="og:description" content="Discover Oasis of Change&#x27;s mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    <meta property="og:url" content="https://www.oasisofchange.com/about">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=About%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="About | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    <meta name="twitter:description" content="Discover Oasis of Change&#x27;s mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=About%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "About | Oasis of Change, Inc.", "description": "Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.", "url": "https://www.oasisofchange.com/about", "image": "https://www.oasisofchange.com/api/og?title=About%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/accessibility_statement.html
+++ b/public/accessibility_statement.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Accessibility Statement | Oasis of Change, Inc.</title>
+        <title>Accessibility Statement | Oasis of Change, Inc.</title>
     <meta name="description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
+    <link rel="canonical" href="https://www.oasisofchange.com/accessibility_statement">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Accessibility Statement | Oasis of Change, Inc.">
     <meta property="og:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
+    <meta property="og:url" content="https://www.oasisofchange.com/accessibility_statement">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Accessibility%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Accessibility Statement | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Accessibility%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Accessibility Statement | Oasis of Change, Inc.", "description": "Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.", "url": "https://www.oasisofchange.com/accessibility_statement", "image": "https://www.oasisofchange.com/api/og?title=Accessibility%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/annual_report_2024_2025.html
+++ b/public/annual_report_2024_2025.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2024–2025 Annual Report | Oasis of Change, Inc.</title>
+        <title>2024–2025 Annual Report | Oasis of Change, Inc.</title>
     <meta name="description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
+    <link rel="canonical" href="https://www.oasisofchange.com/annual_report_2024_2025">
     <meta property="og:type" content="website">
     <meta property="og:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
     <meta property="og:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
+    <meta property="og:url" content="https://www.oasisofchange.com/annual_report_2024_2025">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=2024%E2%80%932025%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=2024%E2%80%932025%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "2024–2025 Annual Report | Oasis of Change, Inc.", "description": "The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.", "url": "https://www.oasisofchange.com/annual_report_2024_2025", "image": "https://www.oasisofchange.com/api/og?title=2024%E2%80%932025%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/annual_report_2025_2026.html
+++ b/public/annual_report_2025_2026.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
+        <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
     <meta name="description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
+    <link rel="canonical" href="https://www.oasisofchange.com/annual_report_2025_2026">
     <meta property="og:type" content="website">
     <meta property="og:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta property="og:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
+    <meta property="og:url" content="https://www.oasisofchange.com/annual_report_2025_2026">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "2025–2026 Annual Report | Oasis of Change, Inc.", "description": "The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.", "url": "https://www.oasisofchange.com/annual_report_2025_2026", "image": "https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/annual_reports.html
+++ b/public/annual_reports.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Annual Reports | Oasis of Change, Inc.</title>
+        <title>Annual Reports | Oasis of Change, Inc.</title>
     <meta name="description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
+    <link rel="canonical" href="https://www.oasisofchange.com/annual_reports">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Annual Reports | Oasis of Change, Inc.">
     <meta property="og:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
+    <meta property="og:url" content="https://www.oasisofchange.com/annual_reports">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Annual%20Reports%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Annual Reports | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Annual%20Reports%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Annual Reports | Oasis of Change, Inc.", "description": "Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.", "url": "https://www.oasisofchange.com/annual_reports", "image": "https://www.oasisofchange.com/api/og?title=Annual%20Reports%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/accessible-web-nonprofits.html
+++ b/public/blog/accessible-web-nonprofits.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.</title>
-    <meta name="description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+        <title>Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.</title>
+    <meta name="description" content="Web accessibility isn&#x27;t optional — it&#x27;s essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/accessible-web-nonprofits">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
-    <meta property="og:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+    <meta property="og:description" content="Web accessibility isn&#x27;t optional — it&#x27;s essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/accessible-web-nonprofits">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Building%20Accessible%20Websites%3A%20A%20Guide%20for%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+    <meta name="twitter:description" content="Web accessibility isn&#x27;t optional — it&#x27;s essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Building%20Accessible%20Websites%3A%20A%20Guide%20for%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.", "description": "Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.", "url": "https://www.oasisofchange.com/blog/accessible-web-nonprofits", "image": "https://www.oasisofchange.com/api/og?title=Building%20Accessible%20Websites%3A%20A%20Guide%20for%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/ai-ethics-environment.html
+++ b/public/blog/ai-ethics-environment.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.</title>
+        <title>AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.</title>
     <meta name="description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/ai-ethics-environment">
     <meta property="og:type" content="article">
     <meta property="og:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
     <meta property="og:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/ai-ethics-environment">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=AI%20and%20the%20Environment%3A%20Balancing%20Innovation%20with%20Responsibility%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=AI%20and%20the%20Environment%3A%20Balancing%20Innovation%20with%20Responsibility%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.", "description": "Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?", "url": "https://www.oasisofchange.com/blog/ai-ethics-environment", "image": "https://www.oasisofchange.com/api/og?title=AI%20and%20the%20Environment%3A%20Balancing%20Innovation%20with%20Responsibility%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/example-article.html
+++ b/public/blog/example-article.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>New Board Directors | Oasis of Change, Inc.</title>
+        <title>New Board Directors | Oasis of Change, Inc.</title>
     <meta name="description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/example-article">
     <meta property="og:type" content="article">
     <meta property="og:title" content="New Board Directors | Oasis of Change, Inc.">
     <meta property="og:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/example-article">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=New%20Board%20Directors%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="New Board Directors | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=New%20Board%20Directors%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "New Board Directors | Oasis of Change, Inc.", "description": "Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.", "url": "https://www.oasisofchange.com/blog/example-article", "image": "https://www.oasisofchange.com/api/og?title=New%20Board%20Directors%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Blog | Oasis of Change, Inc.</title>
+        <title>Blog | Oasis of Change, Inc.</title>
     <meta name="description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Blog | Oasis of Change, Inc.">
     <meta property="og:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Blog%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Blog%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Blog | Oasis of Change, Inc.", "description": "Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.", "url": "https://www.oasisofchange.com/blog/", "image": "https://www.oasisofchange.com/api/og?title=Blog%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/sustainable-web-design.html
+++ b/public/blog/sustainable-web-design.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.</title>
+        <title>What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.</title>
     <meta name="description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/sustainable-web-design">
     <meta property="og:type" content="article">
     <meta property="og:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
     <meta property="og:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/sustainable-web-design">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=What%20Is%20Sustainable%20Web%20Design%3F%20Principles%20and%20Practices%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=What%20Is%20Sustainable%20Web%20Design%3F%20Principles%20and%20Practices%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.", "description": "Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.", "url": "https://www.oasisofchange.com/blog/sustainable-web-design", "image": "https://www.oasisofchange.com/api/og?title=What%20Is%20Sustainable%20Web%20Design%3F%20Principles%20and%20Practices%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/tree-planting-update.html
+++ b/public/blog/tree-planting-update.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.</title>
+        <title>10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.</title>
     <meta name="description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/tree-planting-update">
     <meta property="og:type" content="article">
     <meta property="og:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
     <meta property="og:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/tree-planting-update">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=10%2C000%20Trees%20Planted%3A%20Our%202025%20Reforestation%20Update%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
     <meta name="twitter:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=10%2C000%20Trees%20Planted%3A%20Our%202025%20Reforestation%20Update%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.", "description": "A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.", "url": "https://www.oasisofchange.com/blog/tree-planting-update", "image": "https://www.oasisofchange.com/api/og?title=10%2C000%20Trees%20Planted%3A%20Our%202025%20Reforestation%20Update%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/website-carbon-footprint.html
+++ b/public/blog/website-carbon-footprint.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.</title>
+        <title>Why Your Website&#x27;s Carbon Footprint Matters | Oasis of Change, Inc.</title>
     <meta name="description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/website-carbon-footprint">
     <meta property="og:type" content="article">
-    <meta property="og:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
+    <meta property="og:title" content="Why Your Website&#x27;s Carbon Footprint Matters | Oasis of Change, Inc.">
     <meta property="og:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/website-carbon-footprint">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Why%20Your%20Website%27s%20Carbon%20Footprint%20Matters%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
+    <meta name="twitter:title" content="Why Your Website&#x27;s Carbon Footprint Matters | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Why%20Your%20Website%27s%20Carbon%20Footprint%20Matters%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.", "description": "Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.", "url": "https://www.oasisofchange.com/blog/website-carbon-footprint", "image": "https://www.oasisofchange.com/api/og?title=Why%20Your%20Website%27s%20Carbon%20Footprint%20Matters%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/blog/wra-platform-launch.html
+++ b/public/blog/wra-platform-launch.html
@@ -8,16 +8,24 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.</title>
-    <meta name="description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
+        <title>Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.</title>
+    <meta name="description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here&#x27;s what it is, why we built it, and how to get involved.">
+    <link rel="canonical" href="https://www.oasisofchange.com/blog/wra-platform-launch">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
-    <meta property="og:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
+    <meta property="og:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here&#x27;s what it is, why we built it, and how to get involved.">
+    <meta property="og:url" content="https://www.oasisofchange.com/blog/wra-platform-launch">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Introducing%20the%20WRA%20Platform%3A%20Helping%20Nonprofits%20Go%20Digital%20Sustainably%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
+    <meta name="twitter:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here&#x27;s what it is, why we built it, and how to get involved.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Introducing%20the%20WRA%20Platform%3A%20Helping%20Nonprofits%20Go%20Digital%20Sustainably%20%7C%20Oasis%20of%20Change%2C%20Inc.">
     <meta property="article:author" content="Gabriel Dalton">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.", "description": "The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.", "url": "https://www.oasisofchange.com/blog/wra-platform-launch", "image": "https://www.oasisofchange.com/api/og?title=Introducing%20the%20WRA%20Platform%3A%20Helping%20Nonprofits%20Go%20Digital%20Sustainably%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}, "author": {"@type": "Person", "name": "Gabriel Dalton"}}</script>
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/public/case-studies.html
+++ b/public/case-studies.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Case Studies | Oasis of Change, Inc.</title>
+        <title>Case Studies | Oasis of Change, Inc.</title>
     <meta name="description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
+    <link rel="canonical" href="https://www.oasisofchange.com/case-studies">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Case Studies | Oasis of Change, Inc.">
     <meta property="og:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
+    <meta property="og:url" content="https://www.oasisofchange.com/case-studies">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Case%20Studies%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Case Studies | Oasis of Change, Inc.">
     <meta name="twitter:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Case%20Studies%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Case Studies | Oasis of Change, Inc.", "description": "See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.", "url": "https://www.oasisofchange.com/case-studies", "image": "https://www.oasisofchange.com/api/og?title=Case%20Studies%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/company.html
+++ b/public/company.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Company | Oasis of Change, Inc.</title>
+        <title>Company | Oasis of Change, Inc.</title>
     <meta name="description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
+    <link rel="canonical" href="https://www.oasisofchange.com/company">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Company | Oasis of Change, Inc.">
     <meta property="og:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
+    <meta property="og:url" content="https://www.oasisofchange.com/company">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Company%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Company | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Company%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Company | Oasis of Change, Inc.", "description": "Explore Oasis of Change—our story, mission, leadership, annual reports, and news.", "url": "https://www.oasisofchange.com/company", "image": "https://www.oasisofchange.com/api/og?title=Company%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/contact.html
+++ b/public/contact.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Contact | Oasis of Change, Inc.</title>
+        <title>Contact | Oasis of Change, Inc.</title>
     <meta name="description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
+    <link rel="canonical" href="https://www.oasisofchange.com/contact">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Contact | Oasis of Change, Inc.">
     <meta property="og:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
+    <meta property="og:url" content="https://www.oasisofchange.com/contact">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Contact%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Contact%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Contact | Oasis of Change, Inc.", "description": "Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.", "url": "https://www.oasisofchange.com/contact", "image": "https://www.oasisofchange.com/api/og?title=Contact%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/denman-place-mall.html
+++ b/public/denman-place-mall.html
@@ -9,15 +9,23 @@
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
 
-    <title>Denman Place Mall Case Study | Oasis of Change, Inc.</title>
+        <title>Denman Place Mall Case Study | Oasis of Change, Inc.</title>
     <meta name="description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
+    <link rel="canonical" href="https://www.oasisofchange.com/denman-place-mall">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
     <meta property="og:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
+    <meta property="og:url" content="https://www.oasisofchange.com/denman-place-mall">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Denman%20Place%20Mall%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Denman%20Place%20Mall%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Denman Place Mall Case Study | Oasis of Change, Inc.", "description": "How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.", "url": "https://www.oasisofchange.com/denman-place-mall", "image": "https://www.oasisofchange.com/api/og?title=Denman%20Place%20Mall%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
 
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">

--- a/public/example_annual_report.html
+++ b/public/example_annual_report.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
-    <meta name="description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+        <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
+    <meta name="description" content="Summary of Oasis of Change&#x27;s progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    <link rel="canonical" href="https://www.oasisofchange.com/example_annual_report">
     <meta property="og:type" content="website">
     <meta property="og:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta property="og:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    <meta property="og:description" content="Summary of Oasis of Change&#x27;s progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    <meta property="og:url" content="https://www.oasisofchange.com/example_annual_report">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    <meta name="twitter:description" content="Summary of Oasis of Change&#x27;s progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "2025–2026 Annual Report | Oasis of Change, Inc.", "description": "Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.", "url": "https://www.oasisofchange.com/example_annual_report", "image": "https://www.oasisofchange.com/api/og?title=2025%E2%80%932026%20Annual%20Report%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/gabriel-dalton.html
+++ b/public/gabriel-dalton.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Gabriel Dalton | Oasis of Change, Inc.</title>
+        <title>Gabriel Dalton | Oasis of Change, Inc.</title>
     <meta name="description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
+    <link rel="canonical" href="https://www.oasisofchange.com/gabriel-dalton">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Gabriel Dalton | Oasis of Change, Inc.">
     <meta property="og:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
+    <meta property="og:url" content="https://www.oasisofchange.com/gabriel-dalton">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Gabriel%20Dalton%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Gabriel Dalton | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Gabriel%20Dalton%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Gabriel Dalton | Oasis of Change, Inc.", "description": "Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.", "url": "https://www.oasisofchange.com/gabriel-dalton", "image": "https://www.oasisofchange.com/api/og?title=Gabriel%20Dalton%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/get_involved.html
+++ b/public/get_involved.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Get Involved | Oasis of Change, Inc.</title>
+        <title>Get Involved | Oasis of Change, Inc.</title>
     <meta name="description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
+    <link rel="canonical" href="https://www.oasisofchange.com/get_involved">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Get Involved | Oasis of Change, Inc.">
     <meta property="og:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
+    <meta property="og:url" content="https://www.oasisofchange.com/get_involved">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Get%20Involved%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Get Involved | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Get%20Involved%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Get Involved | Oasis of Change, Inc.", "description": "Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.", "url": "https://www.oasisofchange.com/get_involved", "image": "https://www.oasisofchange.com/api/og?title=Get%20Involved%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/index.html
+++ b/public/index.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Home | Oasis of Change, Inc.</title>
+        <title>Home | Oasis of Change, Inc.</title>
     <meta name="description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
+    <link rel="canonical" href="https://www.oasisofchange.com/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Home | Oasis of Change, Inc.">
     <meta property="og:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
+    <meta property="og:url" content="https://www.oasisofchange.com/">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Home%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Home | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Home%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Home | Oasis of Change, Inc.", "description": "Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.", "url": "https://www.oasisofchange.com/", "image": "https://www.oasisofchange.com/api/og?title=Home%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/initiatives.html
+++ b/public/initiatives.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Initiatives | Oasis of Change, Inc.</title>
+        <title>Initiatives | Oasis of Change, Inc.</title>
     <meta name="description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
+    <link rel="canonical" href="https://www.oasisofchange.com/initiatives">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Initiatives | Oasis of Change, Inc.">
     <meta property="og:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
+    <meta property="og:url" content="https://www.oasisofchange.com/initiatives">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Initiatives%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Initiatives | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Initiatives%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Initiatives | Oasis of Change, Inc.", "description": "Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.", "url": "https://www.oasisofchange.com/initiatives", "image": "https://www.oasisofchange.com/api/og?title=Initiatives%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/mittler-senior-technology.html
+++ b/public/mittler-senior-technology.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Mittler Senior Technology Case Study | Oasis of Change, Inc.</title>
+        <title>Mittler Senior Technology Case Study | Oasis of Change, Inc.</title>
     <meta name="description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
+    <link rel="canonical" href="https://www.oasisofchange.com/mittler-senior-technology">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
     <meta property="og:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
+    <meta property="og:url" content="https://www.oasisofchange.com/mittler-senior-technology">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Mittler%20Senior%20Technology%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Mittler%20Senior%20Technology%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Mittler Senior Technology Case Study | Oasis of Change, Inc.", "description": "Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.", "url": "https://www.oasisofchange.com/mittler-senior-technology", "image": "https://www.oasisofchange.com/api/og?title=Mittler%20Senior%20Technology%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/news-example-post.html
+++ b/public/news-example-post.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Public Impact Dashboard Launch | Oasis of Change, Inc.</title>
+        <title>Public Impact Dashboard Launch | Oasis of Change, Inc.</title>
     <meta name="description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
+    <link rel="canonical" href="https://www.oasisofchange.com/news-example-post">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
     <meta property="og:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
+    <meta property="og:url" content="https://www.oasisofchange.com/news-example-post">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Public%20Impact%20Dashboard%20Launch%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Public%20Impact%20Dashboard%20Launch%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Public Impact Dashboard Launch | Oasis of Change, Inc.", "description": "Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.", "url": "https://www.oasisofchange.com/news-example-post", "image": "https://www.oasisofchange.com/api/og?title=Public%20Impact%20Dashboard%20Launch%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/news_release.html
+++ b/public/news_release.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>News &amp; Media | Oasis of Change, Inc.</title>
+        <title>News &amp; Media | Oasis of Change, Inc.</title>
     <meta name="description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
+    <link rel="canonical" href="https://www.oasisofchange.com/news_release">
     <meta property="og:type" content="website">
     <meta property="og:title" content="News &amp; Media | Oasis of Change, Inc.">
     <meta property="og:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
+    <meta property="og:url" content="https://www.oasisofchange.com/news_release">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=News%20%26%20Media%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="News &amp; Media | Oasis of Change, Inc.">
     <meta name="twitter:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=News%20%26%20Media%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "News & Media | Oasis of Change, Inc.", "description": "News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.", "url": "https://www.oasisofchange.com/news_release", "image": "https://www.oasisofchange.com/api/og?title=News%20%26%20Media%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/nonprofits.html
+++ b/public/nonprofits.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>For Nonprofits | Oasis of Change, Inc.</title>
+        <title>For Nonprofits | Oasis of Change, Inc.</title>
     <meta name="description" content="Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.">
+    <link rel="canonical" href="https://www.oasisofchange.com/nonprofits">
     <meta property="og:type" content="website">
     <meta property="og:title" content="For Nonprofits | Oasis of Change, Inc.">
-    <meta property="og:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
+    <meta property="og:description" content="Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.">
+    <meta property="og:url" content="https://www.oasisofchange.com/nonprofits">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=For%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="For Nonprofits | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
+    <meta name="twitter:description" content="Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=For%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "For Nonprofits | Oasis of Change, Inc.", "description": "Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.", "url": "https://www.oasisofchange.com/nonprofits", "image": "https://www.oasisofchange.com/api/og?title=For%20Nonprofits%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/oasis-of-change-website.html
+++ b/public/oasis-of-change-website.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Oasis of Change Website Case Study | Oasis of Change, Inc.</title>
+        <title>Oasis of Change Website Case Study | Oasis of Change, Inc.</title>
     <meta name="description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
+    <link rel="canonical" href="https://www.oasisofchange.com/oasis-of-change-website">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
     <meta property="og:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
+    <meta property="og:url" content="https://www.oasisofchange.com/oasis-of-change-website">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Oasis%20of%20Change%20Website%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Oasis%20of%20Change%20Website%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Oasis of Change Website Case Study | Oasis of Change, Inc.", "description": "Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.", "url": "https://www.oasisofchange.com/oasis-of-change-website", "image": "https://www.oasisofchange.com/api/og?title=Oasis%20of%20Change%20Website%20Case%20Study%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Privacy Policy | Oasis of Change, Inc.</title>
+        <title>Privacy Policy | Oasis of Change, Inc.</title>
     <meta name="description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
+    <link rel="canonical" href="https://www.oasisofchange.com/privacy-policy">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Privacy Policy | Oasis of Change, Inc.">
     <meta property="og:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
+    <meta property="og:url" content="https://www.oasisofchange.com/privacy-policy">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Privacy%20Policy%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Privacy Policy | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Privacy%20Policy%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Privacy Policy | Oasis of Change, Inc.", "description": "How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.", "url": "https://www.oasisofchange.com/privacy-policy", "image": "https://www.oasisofchange.com/api/og?title=Privacy%20Policy%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/sustainability_statement.html
+++ b/public/sustainability_statement.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Sustainability Statement | Oasis of Change, Inc.</title>
-    <meta name="description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
+        <title>Sustainability Statement | Oasis of Change, Inc.</title>
+    <meta name="description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia&#x27;s clean power grid.">
+    <link rel="canonical" href="https://www.oasisofchange.com/sustainability_statement">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Sustainability Statement | Oasis of Change, Inc.">
-    <meta property="og:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
+    <meta property="og:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia&#x27;s clean power grid.">
+    <meta property="og:url" content="https://www.oasisofchange.com/sustainability_statement">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Sustainability%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainability Statement | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
+    <meta name="twitter:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia&#x27;s clean power grid.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Sustainability%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Sustainability Statement | Oasis of Change, Inc.", "description": "How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.", "url": "https://www.oasisofchange.com/sustainability_statement", "image": "https://www.oasisofchange.com/api/og?title=Sustainability%20Statement%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/sustainable-technology-week.html
+++ b/public/sustainable-technology-week.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Sustainable Technology Week | Oasis of Change, Inc.</title>
+        <title>Sustainable Technology Week | Oasis of Change, Inc.</title>
     <meta name="description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
+    <link rel="canonical" href="https://www.oasisofchange.com/sustainable-technology-week">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
     <meta property="og:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
+    <meta property="og:url" content="https://www.oasisofchange.com/sustainable-technology-week">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Sustainable%20Technology%20Week%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Sustainable%20Technology%20Week%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Sustainable Technology Week | Oasis of Change, Inc.", "description": "Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.", "url": "https://www.oasisofchange.com/sustainable-technology-week", "image": "https://www.oasisofchange.com/api/og?title=Sustainable%20Technology%20Week%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/tree_planting.html
+++ b/public/tree_planting.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Tree Planting &amp; Reforestation | Oasis of Change, Inc.</title>
+        <title>Tree Planting &amp; Reforestation | Oasis of Change, Inc.</title>
     <meta name="description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
+    <link rel="canonical" href="https://www.oasisofchange.com/tree_planting">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
     <meta property="og:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
+    <meta property="og:url" content="https://www.oasisofchange.com/tree_planting">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Tree%20Planting%20%26%20Reforestation%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Tree%20Planting%20%26%20Reforestation%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Tree Planting & Reforestation | Oasis of Change, Inc.", "description": "How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.", "url": "https://www.oasisofchange.com/tree_planting", "image": "https://www.oasisofchange.com/api/og?title=Tree%20Planting%20%26%20Reforestation%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/vcasse.html
+++ b/public/vcasse.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>VCASSE | Oasis of Change, Inc.</title>
+        <title>VCASSE | Oasis of Change, Inc.</title>
     <meta name="description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
+    <link rel="canonical" href="https://www.oasisofchange.com/vcasse">
     <meta property="og:type" content="website">
     <meta property="og:title" content="VCASSE | Oasis of Change, Inc.">
     <meta property="og:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
+    <meta property="og:url" content="https://www.oasisofchange.com/vcasse">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=VCASSE%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="VCASSE | Oasis of Change, Inc.">
     <meta name="twitter:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=VCASSE%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "VCASSE | Oasis of Change, Inc.", "description": "VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.", "url": "https://www.oasisofchange.com/vcasse", "image": "https://www.oasisofchange.com/api/og?title=VCASSE%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/web-ready.html
+++ b/public/web-ready.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Web-Ready | Oasis of Change, Inc.</title>
-    <meta name="description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+        <title>Web-Ready | Oasis of Change, Inc.</title>
+    <meta name="description" content="Web-Ready is Oasis of Change&#x27;s sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    <link rel="canonical" href="https://www.oasisofchange.com/web-ready">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Web-Ready | Oasis of Change, Inc.">
-    <meta property="og:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    <meta property="og:description" content="Web-Ready is Oasis of Change&#x27;s sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    <meta property="og:url" content="https://www.oasisofchange.com/web-ready">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Web-Ready%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    <meta name="twitter:description" content="Web-Ready is Oasis of Change&#x27;s sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Web-Ready%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Web-Ready | Oasis of Change, Inc.", "description": "Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.", "url": "https://www.oasisofchange.com/web-ready", "image": "https://www.oasisofchange.com/api/og?title=Web-Ready%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/public/wra_platform.html
+++ b/public/wra_platform.html
@@ -8,15 +8,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Web-Ready Access Platform | Oasis of Change, Inc.</title>
-    <meta name="description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
+        <title>Web-Ready Access Platform | Oasis of Change, Inc.</title>
+    <meta name="description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change&#x27;s sustainability mission.">
+    <link rel="canonical" href="https://www.oasisofchange.com/wra_platform">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
-    <meta property="og:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
+    <meta property="og:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change&#x27;s sustainability mission.">
+    <meta property="og:url" content="https://www.oasisofchange.com/wra_platform">
     <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="https://www.oasisofchange.com/api/og?title=Web-Ready%20Access%20Platform%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
+    <meta name="twitter:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change&#x27;s sustainability mission.">
+    <meta name="twitter:image" content="https://www.oasisofchange.com/api/og?title=Web-Ready%20Access%20Platform%20%7C%20Oasis%20of%20Change%2C%20Inc.">
+    <script type="application/ld+json">{"@context": "https://schema.org", "@type": "WebPage", "name": "Web-Ready Access Platform | Oasis of Change, Inc.", "description": "Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.", "url": "https://www.oasisofchange.com/wra_platform", "image": "https://www.oasisofchange.com/api/og?title=Web-Ready%20Access%20Platform%20%7C%20Oasis%20of%20Change%2C%20Inc.", "publisher": {"@type": "Organization", "name": "Oasis of Change, Inc.", "url": "https://www.oasisofchange.com", "logo": {"@type": "ImageObject", "url": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg"}}}</script>
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/seo-config.json
+++ b/seo-config.json
@@ -1,0 +1,189 @@
+{
+  "site_url": "https://www.oasisofchange.com",
+  "site_name": "Oasis of Change, Inc.",
+  "site_logo": "https://www.oasisofchange.com/images/logo/Oasis_of_Change-official.svg",
+  "default_og_type": "website",
+  "pages": {
+    "index.html": {
+      "title": "Home | Oasis of Change, Inc.",
+      "description": "Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.",
+      "og_type": "website"
+    },
+    "about.html": {
+      "title": "About | Oasis of Change, Inc.",
+      "description": "Discover Oasis of Change's mission to build a more sustainable digital future\u2014our story, founder Gabriel Dalton, and board of directors.",
+      "og_type": "website"
+    },
+    "company.html": {
+      "title": "Company | Oasis of Change, Inc.",
+      "description": "Explore Oasis of Change\u2014our story, mission, leadership, annual reports, and news.",
+      "og_type": "website"
+    },
+    "contact.html": {
+      "title": "Contact | Oasis of Change, Inc.",
+      "description": "Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.",
+      "og_type": "website"
+    },
+    "initiatives.html": {
+      "title": "Initiatives | Oasis of Change, Inc.",
+      "description": "Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.",
+      "og_type": "website"
+    },
+    "case-studies.html": {
+      "title": "Case Studies | Oasis of Change, Inc.",
+      "description": "See real outcomes from sustainable digital projects\u2014how organizations reduced emissions, energy, and water use with Oasis of Change support.",
+      "og_type": "website"
+    },
+    "nonprofits.html": {
+      "title": "For Nonprofits | Oasis of Change, Inc.",
+      "description": "Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.",
+      "og_type": "website"
+    },
+    "get_involved.html": {
+      "title": "Get Involved | Oasis of Change, Inc.",
+      "description": "Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.",
+      "og_type": "website"
+    },
+    "accessibility_statement.html": {
+      "title": "Accessibility Statement | Oasis of Change, Inc.",
+      "description": "Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.",
+      "og_type": "website"
+    },
+    "privacy-policy.html": {
+      "title": "Privacy Policy | Oasis of Change, Inc.",
+      "description": "How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.",
+      "og_type": "website"
+    },
+    "gabriel-dalton.html": {
+      "title": "Gabriel Dalton | Oasis of Change, Inc.",
+      "description": "Meet Gabriel Dalton, founder of Oasis of Change\u2014a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.",
+      "og_type": "website"
+    },
+    "news_release.html": {
+      "title": "News & Media | Oasis of Change, Inc.",
+      "description": "News releases, media coverage, and public updates from Oasis of Change\u2014launches, partnerships, Sustainable Technology Week, and transparency tools.",
+      "og_type": "website"
+    },
+    "news-example-post.html": {
+      "title": "Public Impact Dashboard Launch | Oasis of Change, Inc.",
+      "description": "Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.",
+      "og_type": "article"
+    },
+    "annual_reports.html": {
+      "title": "Annual Reports | Oasis of Change, Inc.",
+      "description": "Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.",
+      "og_type": "website"
+    },
+    "annual_report_2024_2025.html": {
+      "title": "2024\u20132025 Annual Report | Oasis of Change, Inc.",
+      "description": "The Oasis of Change 2024\u20132025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.",
+      "og_type": "website"
+    },
+    "annual_report_2025_2026.html": {
+      "title": "2025\u20132026 Annual Report | Oasis of Change, Inc.",
+      "description": "The Oasis of Change 2025\u20132026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.",
+      "og_type": "website"
+    },
+    "example_annual_report.html": {
+      "title": "2025\u20132026 Annual Report | Oasis of Change, Inc.",
+      "description": "Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025\u20132026 fiscal year.",
+      "og_type": "website"
+    },
+    "sustainability_statement.html": {
+      "title": "Sustainability Statement | Oasis of Change, Inc.",
+      "description": "How Oasis of Change approaches digital sustainability\u2014AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.",
+      "og_type": "website"
+    },
+    "web-ready.html": {
+      "title": "Web-Ready | Oasis of Change, Inc.",
+      "description": "Web-Ready is Oasis of Change's sustainable website agency\u2014fast, modern, lower-impact sites for nonprofits, communities, and businesses.",
+      "og_type": "website"
+    },
+    "vcasse.html": {
+      "title": "VCASSE | Oasis of Change, Inc.",
+      "description": "VCASSE\u2014the Vancouver Centre for AI Safety, Sustainability, and Ethics\u2014advances responsible AI and environmental stewardship through research and collaboration.",
+      "og_type": "website"
+    },
+    "sustainable-technology-week.html": {
+      "title": "Sustainable Technology Week | Oasis of Change, Inc.",
+      "description": "Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.",
+      "og_type": "website"
+    },
+    "wra_platform.html": {
+      "title": "Web-Ready Access Platform | Oasis of Change, Inc.",
+      "description": "Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.",
+      "og_type": "website"
+    },
+    "tree_planting.html": {
+      "title": "Tree Planting & Reforestation | Oasis of Change, Inc.",
+      "description": "How Oasis of Change reinvests in reforestation and transparent reporting\u2014connecting digital sustainability work to real-world environmental impact.",
+      "og_type": "website"
+    },
+    "oasis-of-change-website.html": {
+      "title": "Oasis of Change Website Case Study | Oasis of Change, Inc.",
+      "description": "Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first\u2014built for clarity, transparency, and low-impact performance.",
+      "og_type": "website"
+    },
+    "denman-place-mall.html": {
+      "title": "Denman Place Mall Case Study | Oasis of Change, Inc.",
+      "description": "How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.",
+      "og_type": "website"
+    },
+    "mittler-senior-technology.html": {
+      "title": "Mittler Senior Technology Case Study | Oasis of Change, Inc.",
+      "description": "Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.",
+      "og_type": "website"
+    },
+    "404.html": {
+      "title": "Page Not Found | Oasis of Change, Inc.",
+      "description": "The page you're looking for doesn't exist or has been moved.",
+      "og_type": "website"
+    },
+    "blog/index.html": {
+      "title": "Blog | Oasis of Change, Inc.",
+      "description": "Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.",
+      "og_type": "website"
+    },
+    "blog/accessible-web-nonprofits.html": {
+      "title": "Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.",
+      "description": "Web accessibility isn't optional \u2014 it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/ai-ethics-environment.html": {
+      "title": "AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.",
+      "description": "Artificial intelligence holds enormous potential for environmental good \u2014 but its own carbon cost is growing fast. How do we build AI responsibly?",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/sustainable-web-design.html": {
+      "title": "What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.",
+      "description": "Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/tree-planting-update.html": {
+      "title": "10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.",
+      "description": "A look back at our 2025 tree planting milestone \u2014 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/website-carbon-footprint.html": {
+      "title": "Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.",
+      "description": "Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution \u2014 and what you can do about it.",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/wra-platform-launch.html": {
+      "title": "Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.",
+      "description": "The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.",
+      "og_type": "article",
+      "article_author": "Gabriel Dalton"
+    },
+    "blog/example-article.html": {
+      "title": "New Board Directors | Oasis of Change, Inc.",
+      "description": "Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.",
+      "og_type": "article"
+    }
+  }
+}

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Page Not Found | Oasis of Change, Inc.</title>
-    <meta name="description" content="The page you're looking for doesn't exist or has been moved.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Page Not Found | Oasis of Change, Inc.">
-    <meta property="og:description" content="The page you're looking for doesn't exist or has been moved.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Page Not Found | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The page you're looking for doesn't exist or has been moved.">
+    {{include seo-head.html}}
     <meta name="robots" content="noindex, nofollow">
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>About | Oasis of Change, Inc.</title>
-    <meta name="description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="About | Oasis of Change, Inc.">
-    <meta property="og:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="About | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/accessibility_statement.html
+++ b/src/pages/accessibility_statement.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Accessibility Statement | Oasis of Change, Inc.</title>
-    <meta name="description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Accessibility Statement | Oasis of Change, Inc.">
-    <meta property="og:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Accessibility Statement | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/annual_report_2024_2025.html
+++ b/src/pages/annual_report_2024_2025.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2024–2025 Annual Report | Oasis of Change, Inc.</title>
-    <meta name="description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
-    <meta property="og:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/annual_report_2025_2026.html
+++ b/src/pages/annual_report_2025_2026.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
-    <meta name="description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta property="og:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/annual_reports.html
+++ b/src/pages/annual_reports.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Annual Reports | Oasis of Change, Inc.</title>
-    <meta name="description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Annual Reports | Oasis of Change, Inc.">
-    <meta property="og:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Annual Reports | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/accessible-web-nonprofits.html
+++ b/src/pages/blog/accessible-web-nonprofits.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.</title>
-    <meta name="description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
-    <meta property="og:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/ai-ethics-environment.html
+++ b/src/pages/blog/ai-ethics-environment.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.</title>
-    <meta name="description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
-    <meta property="og:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/example-article.html
+++ b/src/pages/blog/example-article.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>New Board Directors | Oasis of Change, Inc.</title>
-    <meta name="description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="New Board Directors | Oasis of Change, Inc.">
-    <meta property="og:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="New Board Directors | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/index.html
+++ b/src/pages/blog/index.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Blog | Oasis of Change, Inc.</title>
-    <meta name="description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Blog | Oasis of Change, Inc.">
-    <meta property="og:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Blog | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/sustainable-web-design.html
+++ b/src/pages/blog/sustainable-web-design.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.</title>
-    <meta name="description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
-    <meta property="og:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/tree-planting-update.html
+++ b/src/pages/blog/tree-planting-update.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.</title>
-    <meta name="description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
-    <meta property="og:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/website-carbon-footprint.html
+++ b/src/pages/blog/website-carbon-footprint.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.</title>
-    <meta name="description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
-    <meta property="og:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/blog/wra-platform-launch.html
+++ b/src/pages/blog/wra-platform-launch.html
@@ -8,16 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="../images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="../images/favicon/site.webmanifest">
-    <title>Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.</title>
-    <meta name="description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
-    <meta property="og:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
-    <meta property="article:author" content="Gabriel Dalton">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="../css/fonts.css">
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/case-studies.html
+++ b/src/pages/case-studies.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Case Studies | Oasis of Change, Inc.</title>
-    <meta name="description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Case Studies | Oasis of Change, Inc.">
-    <meta property="og:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Case Studies | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/company.html
+++ b/src/pages/company.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Company | Oasis of Change, Inc.</title>
-    <meta name="description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Company | Oasis of Change, Inc.">
-    <meta property="og:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Company | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Contact | Oasis of Change, Inc.</title>
-    <meta name="description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Contact | Oasis of Change, Inc.">
-    <meta property="og:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contact | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/denman-place-mall.html
+++ b/src/pages/denman-place-mall.html
@@ -9,15 +9,7 @@
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
 
-    <title>Denman Place Mall Case Study | Oasis of Change, Inc.</title>
-    <meta name="description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
-    <meta property="og:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
+    {{include seo-head.html}}
 
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">

--- a/src/pages/example_annual_report.html
+++ b/src/pages/example_annual_report.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>2025–2026 Annual Report | Oasis of Change, Inc.</title>
-    <meta name="description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta property="og:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/gabriel-dalton.html
+++ b/src/pages/gabriel-dalton.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Gabriel Dalton | Oasis of Change, Inc.</title>
-    <meta name="description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Gabriel Dalton | Oasis of Change, Inc.">
-    <meta property="og:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Gabriel Dalton | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/get_involved.html
+++ b/src/pages/get_involved.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Get Involved | Oasis of Change, Inc.</title>
-    <meta name="description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Get Involved | Oasis of Change, Inc.">
-    <meta property="og:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Get Involved | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Home | Oasis of Change, Inc.</title>
-    <meta name="description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Home | Oasis of Change, Inc.">
-    <meta property="og:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Home | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/initiatives.html
+++ b/src/pages/initiatives.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Initiatives | Oasis of Change, Inc.</title>
-    <meta name="description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Initiatives | Oasis of Change, Inc.">
-    <meta property="og:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Initiatives | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/mittler-senior-technology.html
+++ b/src/pages/mittler-senior-technology.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Mittler Senior Technology Case Study | Oasis of Change, Inc.</title>
-    <meta name="description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
-    <meta property="og:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/news-example-post.html
+++ b/src/pages/news-example-post.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Public Impact Dashboard Launch | Oasis of Change, Inc.</title>
-    <meta name="description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
-    <meta property="og:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/news_release.html
+++ b/src/pages/news_release.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>News &amp; Media | Oasis of Change, Inc.</title>
-    <meta name="description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="News &amp; Media | Oasis of Change, Inc.">
-    <meta property="og:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="News &amp; Media | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/nonprofits.html
+++ b/src/pages/nonprofits.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>For Nonprofits | Oasis of Change, Inc.</title>
-    <meta name="description" content="Oasis of Change partners with nonprofits to secure technology grants, reduce website carbon and energy use, and improve accessibility through our Web-Ready programme.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="For Nonprofits | Oasis of Change, Inc.">
-    <meta property="og:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="For Nonprofits | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/oasis-of-change-website.html
+++ b/src/pages/oasis-of-change-website.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Oasis of Change Website Case Study | Oasis of Change, Inc.</title>
-    <meta name="description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
-    <meta property="og:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/privacy-policy.html
+++ b/src/pages/privacy-policy.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Privacy Policy | Oasis of Change, Inc.</title>
-    <meta name="description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Privacy Policy | Oasis of Change, Inc.">
-    <meta property="og:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Privacy Policy | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/sustainability_statement.html
+++ b/src/pages/sustainability_statement.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Sustainability Statement | Oasis of Change, Inc.</title>
-    <meta name="description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Sustainability Statement | Oasis of Change, Inc.">
-    <meta property="og:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Sustainability Statement | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/sustainable-technology-week.html
+++ b/src/pages/sustainable-technology-week.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Sustainable Technology Week | Oasis of Change, Inc.</title>
-    <meta name="description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
-    <meta property="og:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/tree_planting.html
+++ b/src/pages/tree_planting.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Tree Planting &amp; Reforestation | Oasis of Change, Inc.</title>
-    <meta name="description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
-    <meta property="og:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/vcasse.html
+++ b/src/pages/vcasse.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>VCASSE | Oasis of Change, Inc.</title>
-    <meta name="description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="VCASSE | Oasis of Change, Inc.">
-    <meta property="og:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="VCASSE | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/web-ready.html
+++ b/src/pages/web-ready.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Web-Ready | Oasis of Change, Inc.</title>
-    <meta name="description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Web-Ready | Oasis of Change, Inc.">
-    <meta property="og:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Web-Ready | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/pages/wra_platform.html
+++ b/src/pages/wra_platform.html
@@ -8,15 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
     <link rel="apple-touch-icon" href="images/favicon/apple-touch-icon.png">
     <link rel="manifest" href="images/favicon/site.webmanifest">
-    <title>Web-Ready Access Platform | Oasis of Change, Inc.</title>
-    <meta name="description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
-    <meta property="og:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
-    <meta property="og:site_name" content="Oasis of Change, Inc.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
-    <meta name="twitter:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
+    {{include seo-head.html}}
     <link rel="stylesheet" href="css/fonts.css">
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">

--- a/src/partials/seo-head.html
+++ b/src/partials/seo-head.html
@@ -1,0 +1,17 @@
+    <title>{{seo_title}}</title>
+    <meta name="description" content="{{seo_description}}">
+    <link rel="canonical" href="{{seo_canonical}}">
+    <meta property="og:type" content="{{seo_og_type}}">
+    <meta property="og:title" content="{{seo_title}}">
+    <meta property="og:description" content="{{seo_description}}">
+    <meta property="og:url" content="{{seo_canonical}}">
+    <meta property="og:site_name" content="Oasis of Change, Inc.">
+    <meta property="og:image" content="{{seo_og_image}}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{seo_title}}">
+    <meta name="twitter:description" content="{{seo_description}}">
+    <meta name="twitter:image" content="{{seo_og_image}}">
+{{seo_extra_meta}}{{seo_jsonld}}


### PR DESCRIPTION
## Summary

- **Dynamic OG image generation** via a new Vercel Edge function (`/api/og`) that renders branded 1200×630 social cards per page using `@vercel/og`
- **Centralized SEO config** (`seo-config.json`) — single source of truth for all 35 pages' titles, descriptions, OG types, and article authors
- **Template-driven meta tags** — new `seo-head.html` partial replaces hardcoded meta blocks across all pages, adding canonical URLs, `og:url`, `og:image`, `twitter:image`, and JSON-LD structured data (WebPage / Article schemas)
- **Enhanced build system** — `build.py` now loads `seo-config.json` and injects per-page SEO variables during build

### What was missing before
| Tag | Before | After |
|-----|--------|-------|
| `og:image` / `twitter:image` | Missing | Dynamic branded card via `/api/og` |
| `og:url` | Missing | Full canonical URL |
| `<link rel="canonical">` | Missing | Auto-generated from page path |
| JSON-LD structured data | Missing | `WebPage` or `Article` schema |

## Test plan

- [ ] Run `python3 build.py` — builds 35 pages without errors
- [ ] Inspect `public/index.html` head for canonical, og:image, og:url, and JSON-LD script tag
- [ ] Inspect a blog article (e.g. `public/blog/sustainable-web-design.html`) for `article:author`, Article JSON-LD, and correct `og:type=article`
- [ ] Deploy to Vercel preview and hit `/api/og?title=Test` — should return a 1200×630 PNG image
- [ ] Validate a page with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) or [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] Confirm `seo-config.json` entries match existing page titles/descriptions (no regressions)

https://claude.ai/code/session_01QhoY1HZyiFCjdBkaL1kDg1