### PR TITLE
Improve select field layout with horizontal alignment

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -677,6 +677,20 @@
   flex-direction: column;
   gap: 0.375rem;
 }
+.cf-field:has(select.cf-input) {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+.cf-field:has(select.cf-input) .cf-label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  min-width: max-content;
+}
+.cf-field:has(select.cf-input) select.cf-input {
+  flex: 1;
+  min-width: 0;
+}
 .cf-label {
   font-size: 0.875rem;
   font-weight: 500;


### PR DESCRIPTION
## Summary
Updated the styling for select input fields to use a horizontal layout instead of vertical, improving the visual presentation and space efficiency of dropdown form fields.

## Key Changes
- Modified `.cf-field:has(select.cf-input)` to use `flex-direction: row` with centered alignment
- Adjusted gap spacing from `0.375rem` to `0.75rem` for better visual separation
- Configured `.cf-label` within select fields to prevent wrapping and maintain consistent width
- Set select input to flex and grow to fill available space while maintaining minimum width constraints

## Implementation Details
- Used CSS `:has()` selector to target field containers with select inputs
- Applied `flex: 0 0 auto` to labels to preserve their natural width
- Applied `flex: 1` to select inputs to allow them to expand and fill remaining space
- Added `min-width: 0` to select inputs to ensure flex shrinking works properly

https://claude.ai/code/session_019wqdcdaS5f4Zn5xwTs2wLq