### PR TITLE
Update press contact button text and styling

### DIFF
--- a/src/pages/get-involved/index.html
+++ b/src/pages/get-involved/index.html
@@ -262,7 +262,7 @@
                   <h2 class="text-2xl md:text-3xl font-heading tracking-tight mb-4">Press &amp; media</h2>
                   <p class="text-gray-300 leading-7 md:leading-8 mb-6 flex-1">For interviews, stories, features, speaking requests, or other press inquiries, get in touch and we will route your message appropriately.</p>
                   <div>
-                    <a href="{{base}}contact.html?type=media" class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold tracking-tight text-black hover:bg-gray-100 transition duration-200">Let's Chat About Press &amp; Media</a>
+                    <a href="{{base}}contact.html?type=media" class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-xs font-semibold tracking-tight text-black hover:bg-gray-100 transition duration-200">Let's chat about press</a>
                   </div>
                 </div>
                 <div class="rounded-2xl bg-black p-6 md:p-8 text-white flex flex-col">


### PR DESCRIPTION
## Summary
Updated the "Press & media" contact button on the get-involved page with improved text and styling adjustments.

## Changes
- Changed button text from "Let's Chat About Press & Media" to "Let's chat about press" for a more concise and casual tone
- Updated button text size from `text-sm` to `text-xs` to better fit the button dimensions

## Details
These changes improve the visual hierarchy and readability of the press contact button while maintaining its functionality and link to the contact form with the media inquiry type parameter.

https://claude.ai/code/session_01XyetRuzwppSjjkHQgwb1to