### PR TITLE
404: add <base href="/"> so fallback renders correctly at nested URLs

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Resolve all relative URLs against the site root so this page renders correctly
+         when Vercel serves it as the fallback for unknown paths like /tedx/company. -->
+    <base href="/">
     <link rel="icon" href="images/favicon/favicon.ico" type="image/x-icon">
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Resolve all relative URLs against the site root so this page renders correctly
+         when Vercel serves it as the fallback for unknown paths like /tedx/company. -->
+    <base href="/">
     <link rel="icon" href="images/favicon/favicon.ico" type="image/x-icon">
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">


### PR DESCRIPTION
When Vercel served 404.html for an unknown deep URL (e.g. /tedx/company or
/tedx-a-talk/2), the browser resolved the page's relative asset paths against
the requested URL — so css/site.css became /tedx/css/site.css, which 404'd,
producing an unstyled, broken-looking page. Setting <base href="/"> forces all
relative links, assets, and footer URLs to resolve against the site root.