### PR TITLE
fix: stat-tile headings overflow narrow viewports

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -240,7 +240,7 @@
             </div>
           </nav>
 
-          <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6 px-8 md:px-24">
+          <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6 px-4 sm:px-6 md:px-12 lg:px-24">
             <a href="index.html" class="hover:text-black transition">Home</a>
             <span class="mx-2" aria-hidden="true">/</span>
             <a href="company.html" class="hover:text-black transition">Company</a>
@@ -248,15 +248,15 @@
             <span class="text-gray-600">Our Story</span>
           </nav>
 
-          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-24 px-8 md:px-24">
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/2 p-4">
+          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 px-4 sm:px-6 md:px-12 lg:px-24">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8">
+              <div>
                 <p class="mb-4 tracking-tight">About <span translate="no">Oasis of Change</span></p>
-                <h1 translate="no" class="text-4xl md:text-6xl font-medium tracking-tight mb-16 max-w-xs md:max-w-lg text-black">              Building a more sustainable digital future</h1>
-                <img class="about-hero-image-mobile-hidden rounded-2xl lg:ml-auto object-cover" style="height:419px;" src="images/about/about-page-block-1.webp" alt="Oasis of Change — building sustainable digital experiences" width="353" height="419" loading="lazy">
+                <h1 translate="no" class="text-4xl md:text-6xl font-medium tracking-tight mb-10 sm:mb-12 md:mb-16 md:max-w-lg text-black">Building a more sustainable digital future</h1>
+                <img class="about-hero-image-mobile-hidden rounded-2xl lg:ml-auto object-cover w-full h-[260px] sm:h-[320px] md:h-[380px] lg:h-[419px]" src="images/about/about-page-block-1.webp" alt="Oasis of Change — building sustainable digital experiences" width="353" height="419" loading="lazy">
               </div>
-              <div class="w-full lg:w-1/2 p-4">
-                <img class="rounded-2xl mb-20 object-cover object-right" style="height:516px;" src="images/about/about-page-block-2.webp" srcset="images/about/about-page-block-2-400w.webp 400w, images/about/about-page-block-2-800w.webp 800w, images/about/about-page-block-2.webp 1024w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Founded in 2024" width="1024" height="1024" loading="lazy">
+              <div>
+                <img class="rounded-2xl mb-10 sm:mb-14 md:mb-20 object-cover object-right w-full h-[260px] sm:h-[360px] md:h-[440px] lg:h-[516px]" src="images/about/about-page-block-2.webp" srcset="images/about/about-page-block-2-400w.webp 400w, images/about/about-page-block-2-800w.webp 800w, images/about/about-page-block-2.webp 1024w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Founded in 2024" width="1024" height="1024" loading="lazy">
                 <p class="tracking-tight text-lg max-w-lg"><span translate="no">Oasis of Change</span> was founded to promote digital sustainability through low-carbon, energy-efficient websites and practical innovation that helps people rethink the environmental impact of technology.</p>
               </div>
             </div>
@@ -303,10 +303,10 @@
           </div>
         </div>
       </section>
-      <section class="px-6 md:px-16 lg:px-24 py-24"><div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20"><div class="grid lg:grid-cols-2 gap-12 items-center"><!-- Portrait --><div><div class="bg-white rounded-2xl overflow-hidden"><img class="w-full object-cover" src="images/about/Gabriel-Dalton.webp" srcset="images/about/Gabriel-Dalton-400w.webp 400w, images/about/Gabriel-Dalton.webp 512w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Gabriel Dalton portrait" width="743" height="1075" loading="lazy"></div></div><!-- Bio --><div><p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Founder</p><h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold mb-6">Gabriel Dalton</h2><p class="text-gray-300 text-lg mb-6 max-w-xl">Gabriel Dalton is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. After teaching himself to code at age 10, he began exploring how websites and digital infrastructure impact energy consumption, emissions, and global resources.</p><p class="text-gray-300 text-lg mb-8 max-w-xl">Today his work focuses on building low-carbon websites, improving digital efficiency, and helping organizations reduce the environmental footprint of the internet. His work in sustainable web development earned him the Youth Impact &amp; Innovation Award at the 2025 Vancouver Awards.</p><div class="flex items-center gap-6"><a href="contact.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Get in Touch</a><a href="about.html" class="text-white font-semibold hover:underline" aria-label="Learn more about our story">Learn More →</a></div></div></div></div></section>
-      <section id="our-board" class="px-6 md:px-16 lg:px-24 py-24">
-        <div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20 text-white">
-          <div class="mb-14 text-center">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24"><div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20"><div class="grid lg:grid-cols-2 gap-10 lg:gap-12 items-center"><!-- Portrait --><div><div class="bg-white rounded-2xl overflow-hidden"><img class="w-full object-cover" src="images/about/Gabriel-Dalton.webp" srcset="images/about/Gabriel-Dalton-400w.webp 400w, images/about/Gabriel-Dalton.webp 512w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Gabriel Dalton portrait" width="743" height="1075" loading="lazy"></div></div><!-- Bio --><div><p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Founder</p><h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold mb-6">Gabriel Dalton</h2><p class="text-gray-300 text-lg mb-6 max-w-xl">Gabriel Dalton is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. After teaching himself to code at age 10, he began exploring how websites and digital infrastructure impact energy consumption, emissions, and global resources.</p><p class="text-gray-300 text-lg mb-8 max-w-xl">Today his work focuses on building low-carbon websites, improving digital efficiency, and helping organizations reduce the environmental footprint of the internet. His work in sustainable web development earned him the Youth Impact &amp; Innovation Award at the 2025 Vancouver Awards.</p><div class="flex items-center gap-6"><a href="contact.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Get in Touch</a><a href="about.html" class="text-white font-semibold hover:underline" aria-label="Learn more about our story">Learn More →</a></div></div></div></div></section>
+      <section id="our-board" class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24">
+        <div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20 text-white">
+          <div class="mb-10 sm:mb-14 text-center">
             <p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Leadership</p>
             <h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold">Board of Directors</h2>
           </div>
@@ -355,8 +355,8 @@
           </div>
         </div>
       </section>
-      <section class="px-6 md:px-16 lg:px-24 py-24" aria-labelledby="oasis-name-title">
-        <div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20 text-white">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24" aria-labelledby="oasis-name-title">
+        <div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20 text-white">
           <div class="max-w-3xl mx-auto">
             <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-white/60 mb-6">Our Name</p>
             <h2 id="oasis-name-title" class="font-heading tracking-tight text-3xl md:text-4xl font-semibold mb-4">

--- a/public/annual-report/2024-2025/index.html
+++ b/public/annual-report/2024-2025/index.html
@@ -243,22 +243,22 @@
               <p class="text-xs uppercase tracking-[0.18em] text-gray-600 mb-6">Year in numbers</p>
               <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">675</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">675</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Mangroves planted</p>
                   <p class="text-gray-300 leading-6 text-sm">Mangrove trees funded in Madagascar through Eden Reforestation Projects.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">34,000 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">34,000 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂ offset</p>
                   <p class="text-gray-300 leading-6 text-sm">Estimated lifetime carbon sequestration from the year's mangrove planting.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">1</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">1</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Country reached</p>
                   <p class="text-gray-300 leading-6 text-sm">Madagascar, where restored mangroves protect coastal ecosystems and livelihoods.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">2</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">2</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Initiatives active</p>
                   <p class="text-gray-300 leading-6 text-sm"><span translate="no">Web-Ready</span> sustainable web development and the municipal proclamation campaign.</p>
                 </div>

--- a/public/annual-report/2025-2026/index.html
+++ b/public/annual-report/2025-2026/index.html
@@ -243,22 +243,22 @@
               <p class="text-xs uppercase tracking-[0.18em] text-gray-600 mb-6">Year in numbers</p>
               <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">7,144</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">7,144</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Trees planted this year</p>
                   <p class="text-gray-300 leading-6 text-sm">A 958% year-over-year increase across 14 countries on 6 continents.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">~360,000 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">~360,000 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂ offset, reforestation</p>
                   <p class="text-gray-300 leading-6 text-sm">Estimated lifetime carbon impact of this year's plantings, a 963% year-over-year increase.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">Up to 98%</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">Up to 98%</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Digital emissions cut</p>
                   <p class="text-gray-300 leading-6 text-sm">Reductions in carbon, energy, and water use achieved on client website projects.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">516 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">516 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂e, hardware recycling</p>
                   <p class="text-gray-300 leading-6 text-sm">Emissions avoided by responsibly recycling two end-of-life laptops to DoD 5220.22-M standards.</p>
                 </div>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -231,15 +231,15 @@
         </div>
       </section>
                 
-      <section class="px-8 md:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 md:pb-20">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 md:pb-20">
         <nav aria-label="Breadcrumb" class="text-sm text-gray-600 max-w-6xl mx-auto mb-8">
           <a href="../index.html" class="hover:text-black transition">Home</a>
           <span class="mx-2" aria-hidden="true">/</span>
           <span class="text-gray-600">Blog</span>
         </nav>
-        <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium text-center mb-14 text-black">Latest from our blog</h1>
-        <div class="flex flex-wrap -m-4 mb-10">
-          <div class="w-full lg:w-1/3 p-4">
+        <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium text-center mb-10 sm:mb-14 text-black">Latest from our blog</h1>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 mb-10">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="ai-ethics-environment.html"><img class="w-full object-cover h-56" src="../images/blog/blog-ai-network-visualization.webp" alt="Abstract visualization of AI network connections" width="416" height="307" loading="lazy"></a>
@@ -255,7 +255,7 @@
               </div>
             </div>
           </div>
-          <div class="w-full lg:w-1/3 p-4">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="sustainable-web-design.html"><img class="w-full object-cover h-56" src="../images/blog/blog-minimal-website-design.webp" alt="Clean minimal website design on a monitor" width="416" height="307" loading="lazy"></a>
@@ -271,7 +271,7 @@
               </div>
             </div>
           </div>
-          <div class="w-full lg:w-1/3 p-4">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="website-carbon-footprint.html"><img class="w-full object-cover h-56" src="../images/blog/blog-data-center-hardware.webp" alt="Server room with data centre hardware" width="416" height="233" loading="lazy"></a>
@@ -287,7 +287,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="accessible-web-nonprofits.html"><img class="w-full object-cover h-56" src="../images/blog/blog-assistive-technology.webp" alt="Person using assistive technology on a laptop" width="416" height="233" loading="lazy"></a>
@@ -303,7 +303,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="wra-platform-launch.html"><img class="w-full object-cover h-56" src="../images/blog/blog-nonprofit-team-review.webp" alt="Nonprofit team reviewing their website on a shared screen" width="416" height="307" loading="lazy"></a>
@@ -319,7 +319,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="tree-planting-update.html"><img class="w-full object-cover h-56" src="../images/blog/blog-reforestation-saplings.webp" alt="Newly planted saplings at a reforestation site" width="416" height="233" loading="lazy"></a>

--- a/public/case-studies/breathwave/index.html
+++ b/public/case-studies/breathwave/index.html
@@ -246,8 +246,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 right-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl"><span translate="no">Breathwave</span>, now faster and more accessible than ever</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">We built <span translate="no">Breathwave</span>'s website in 2023 and have kept improving it since. This April, we re-optimized for speed and accessibility, with measurable gains across the board.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl"><span translate="no">Breathwave</span>, now faster and more accessible than ever</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">We built <span translate="no">Breathwave</span>'s website in 2023 and have kept improving it since. This April, we re-optimized for speed and accessibility, with measurable gains across the board.</p>
               </div>
             </div>
           </div>

--- a/public/case-studies/denman-place-mall/index.html
+++ b/public/case-studies/denman-place-mall/index.html
@@ -249,8 +249,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl">Rebuilding the<span translate="no"> Denman Place Mall </span>website around its visitors</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">The majority of visitors arrive on mobile devices within walking distance of the mall. They need store information, hours, and directions. The previous site was not designed with those priorities in mind.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl">Rebuilding the<span translate="no"> Denman Place Mall </span>website around its visitors</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">The majority of visitors arrive on mobile devices within walking distance of the mall. They need store information, hours, and directions. The previous site was not designed with those priorities in mind.</p>
               </div>
             </div>
           </div>
@@ -341,20 +341,20 @@
             </p>
 
             <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Accessible</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Accessible</h3>
                 <p class="tracking-tight text-gray-600">Usable by a wider audience</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Lean</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Lean</h3>
                 <p class="tracking-tight text-gray-600">Reduced page weight throughout</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Maintainable</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Maintainable</h3>
                 <p class="tracking-tight text-gray-600">Built for long-term stability</p>
               </div>
             </div>
@@ -388,38 +388,32 @@
               </p>
             </div>
 
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Faster
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Page load times improved through the removal of render-blocking resources, image compression, and reduced markup throughout the site.
-                  </p>
-                </div>
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Faster
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Page load times improved through the removal of render-blocking resources, image compression, and reduced markup throughout the site.
+                </p>
               </div>
 
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Clearer
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Store directories, hours, and location information are now positioned consistently. Navigation follows the same structure across every page.
-                  </p>
-                </div>
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Clearer
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Store directories, hours, and location information are now positioned consistently. Navigation follows the same structure across every page.
+                </p>
               </div>
 
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Lighter
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    The overall site footprint is significantly smaller, resulting in lower server resource usage, reduced energy consumption per visit, and simplified ongoing maintenance.
-                  </p>
-                </div>
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Lighter
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  The overall site footprint is significantly smaller, resulting in lower server resource usage, reduced energy consumption per visit, and simplified ongoing maintenance.
+                </p>
               </div>
             </div>
           </div>

--- a/public/case-studies/denman-place-mall/index.html
+++ b/public/case-studies/denman-place-mall/index.html
@@ -340,7 +340,7 @@
               <span translate="no">Denman Place Mall</span> is located on one of the busiest pedestrian streets in Vancouver’s West End. It serves a daily-needs function for the surrounding community: groceries, services, dining. The website needed to reflect that purpose: fast to load, easy to navigate, and optimized for mobile screens.
             </p>
 
-            <div class="grid grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
+            <div class="grid grid-cols-2 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
               <div class="min-w-0">
                 <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>

--- a/public/case-studies/denman-place-mall/index.html
+++ b/public/case-studies/denman-place-mall/index.html
@@ -340,7 +340,7 @@
               <span translate="no">Denman Place Mall</span> is located on one of the busiest pedestrian streets in Vancouver’s West End. It serves a daily-needs function for the surrounding community: groceries, services, dining. The website needed to reflect that purpose: fast to load, easy to navigate, and optimized for mobile screens.
             </p>
 
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
+            <div class="grid grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
               <div class="min-w-0">
                 <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>

--- a/public/case-studies/mittler-senior-technology/index.html
+++ b/public/case-studies/mittler-senior-technology/index.html
@@ -247,8 +247,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl"><span translate="no">Mittler Senior Technology </span>achieved a 98.2% energy reduction</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">From an F rating to a B rating, this transformation shows how digital sustainability can cut emissions, energy use, and water consumption at scale.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl"><span translate="no">Mittler Senior Technology </span>achieved a 98.2% energy reduction</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">From an F rating to a B rating, this transformation shows how digital sustainability can cut emissions, energy use, and water consumption at scale.</p>
               </div>
             </div>
           </div>
@@ -385,47 +385,41 @@
               </p>
             </div>
       
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.2%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Energy reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
-                  </p>
-                </div>
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.2%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Energy reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
+                </p>
               </div>
-      
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Carbon reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
-                  </p>
-                </div>
+
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.1%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Carbon reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
+                </p>
               </div>
-      
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Water reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
-                  </p>
-                </div>
+
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.1%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Water reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
+                </p>
               </div>
             </div>
           </div>

--- a/public/case-studies/oasis-of-change-website/index.html
+++ b/public/case-studies/oasis-of-change-website/index.html
@@ -248,8 +248,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl">How we built the<span translate="no"> Oasis of Change </span>website to be sustainability-first</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">A transparent, low-impact site that prioritizes performance, accessibility, and clarity—without sacrificing design quality.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl">How we built the<span translate="no"> Oasis of Change </span>website to be sustainability-first</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">A transparent, low-impact site that prioritizes performance, accessibility, and clarity—without sacrificing design quality.</p>
               </div>
             </div>
           </div>

--- a/public/company.html
+++ b/public/company.html
@@ -235,7 +235,7 @@
             <span class="text-gray-600">Company</span>
           </nav>
 
-          <section class="pb-20 md:pb-28 px-8 md:px-24 mb-12 md:mb-16" aria-labelledby="company-hub-title">
+          <section class="pb-16 sm:pb-20 md:pb-28 px-4 sm:px-6 md:px-12 lg:px-24 mb-12 md:mb-16" aria-labelledby="company-hub-title">
             <div class="max-w-6xl mx-auto">
               <h1 id="company-hub-title" class="font-heading text-3xl sm:text-4xl md:text-5xl font-medium tracking-tight text-black mb-4 max-w-3xl leading-[1.08]">Company</h1>
               <p class="text-base sm:text-lg text-gray-600 leading-7 sm:leading-8 max-w-2xl mb-12 md:mb-14">Who we are, what we stand for, how we are governed, and where to find official updates—everything under Company in one place.</p>

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -489,6 +489,10 @@
   .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
+@media (min-width: 1024px) {
+  .lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
+}
+
 .items-start { align-items: flex-start; }
 .text-green-800 { color: #166534; }
 .text-gray-400  { color: #9ca3af; }

--- a/public/gabriel-dalton.html
+++ b/public/gabriel-dalton.html
@@ -235,7 +235,7 @@
         </div>
       </section>
                 
-      <section class="pt-4 sm:pt-6 md:pt-8 lg:pt-10 pb-24 px-6 md:px-16 lg:px-24">
+      <section class="pt-4 sm:pt-6 md:pt-8 lg:pt-10 pb-16 sm:pb-20 md:pb-24 px-4 sm:px-6 md:px-12 lg:px-24">
         <div class="max-w-6xl mx-auto">
           <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6">
             <a href="index.html" class="hover:text-black transition">Home</a>
@@ -244,8 +244,8 @@
             <span class="mx-2" aria-hidden="true">/</span>
             <span class="text-gray-600">Our Founder</span>
           </nav>
-          <div class="grid lg:grid-cols-2 gap-16 items-center">
-      
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+
           <!-- Text -->
           <div>
             <h1 class="font-heading text-4xl md:text-5xl lg:text-6xl font-medium tracking-tight mb-6 text-black">
@@ -256,7 +256,7 @@
               Gabriel is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. His work explores how the internet impacts energy use, emissions, and global resources.
             </p>
 
-            <a href="#bio" class="bg-black h-14 px-6 rounded-full inline-flex items-center justify-center hover:bg-green-400 transition font-semibold text-white">
+            <a href="#bio" class="bg-black min-h-14 px-6 py-3 rounded-full inline-flex items-center justify-center hover:bg-green-400 transition font-semibold text-white w-full sm:w-auto">
               Read Full Biography
             </a>
           </div>
@@ -270,9 +270,9 @@
         </div>
       </section>
                 
-      <section id="bio" class="py-28 px-6 md:px-16 lg:px-24">
+      <section id="bio" class="py-16 sm:py-20 md:py-24 lg:py-28 px-4 sm:px-6 md:px-12 lg:px-24">
         <div class="max-w-4xl mx-auto">
-      
+
           <h2 class="font-heading text-3xl md:text-4xl font-medium tracking-tight mb-10 text-black">
             About Gabriel Dalton
           </h2>
@@ -304,7 +304,7 @@
         </div>
       </section>
                 
-      <section class="px-4 sm:px-6 md:px-12 py-20 md:py-24 bg-black">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24 bg-black">
         <div class="max-w-6xl mx-auto">
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
             <div>

--- a/public/get-involved/index.html
+++ b/public/get-involved/index.html
@@ -230,7 +230,7 @@
           </nav>
 
           <!-- GET INVOLVED PAGE -->
-          <section class="px-6 md:px-12 lg:px-24 pt-10 md:pt-16 lg:pt-20 pb-20 md:pb-28 lg:pb-32">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-16 lg:pt-20 pb-16 sm:pb-20 md:pb-28 lg:pb-32">
             <div class="max-w-6xl mx-auto">
               <!-- BREADCRUMB -->
               <nav aria-label="Breadcrumb" class="text-sm text-gray-500 mb-8">

--- a/public/initiatives/web-ready/index.html
+++ b/public/initiatives/web-ready/index.html
@@ -239,11 +239,11 @@
 
       
           <!-- Hero -->
-          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 md:pb-24 lg:pb-32">
-            <div class="flex flex-wrap items-center -m-4">
-              <div class="w-full lg:w-1/2 p-4">
+          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-32">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8 items-center">
+              <div>
                 <p class="tracking-tight text-gray-600 font-medium mb-4">Subsidiary Project</p>
-                <h2 class="font-heading tracking-tight text-4xl md:text-6xl font-medium max-w-sm md:max-w-2xl mb-5 leading-[1.02] text-black">
+                <h2 class="font-heading tracking-tight text-4xl md:text-6xl font-medium md:max-w-2xl mb-5 leading-[1.02] text-black">
                   <span translate="no">Web-Ready</span>
                 </h2>
                 <p class="tracking-tight text-gray-600 text-lg leading-8 mb-6 max-w-xl">
@@ -253,14 +253,14 @@
                   It focuses on building websites that are fast, modern, lower-impact, and designed to support real growth for nonprofits, community organizations, and businesses.
                 </p>
                 <div class="flex flex-wrap items-center gap-4">
-                  <a href="https://web-ready.org" target="_blank" rel="noopener noreferrer" class="h-16 rounded-full px-6 py-4 inline-flex items-center justify-center gap-1 border border-gray-200 hover:bg-gray-50 focus:bg-gray-50 focus:ring-4 focus:ring-gray-100 transition duration-200 tracking-tight font-bold text-black">
+                  <a href="https://web-ready.org" target="_blank" rel="noopener noreferrer" class="min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-1 border border-gray-200 hover:bg-gray-50 focus:bg-gray-50 focus:ring-4 focus:ring-gray-100 transition duration-200 tracking-tight font-semibold text-black w-full sm:w-auto">
                     <span>Visit</span>
                     <span translate="no">Web-Ready</span>
                   </a>
                 </div>
               </div>
-      
-              <div class="w-full lg:w-1/2 p-4">
+
+              <div>
                 <div class="lg:ml-auto w-full max-w-lg rounded-[2rem] border border-black/5 bg-white p-6 md:p-8 shadow-sm">
                   <div class="overflow-hidden rounded-2xl bg-[#f3f4f3] ring-1 ring-black/[0.06] flex items-center justify-center p-6 sm:p-8 md:p-10 min-h-[280px] sm:min-h-[360px]">
                     <img class="w-full max-h-[320px] sm:max-h-[380px] object-contain object-center rounded-2xl" src="../../images/logo/web-ready-logo.webp" srcset="../../images/logo/web-ready-logo-400w.webp 400w, ../../images/logo/web-ready-logo.webp 500w" sizes="(max-width: 640px) 100vw, 400px" alt="Web-Ready logo" width="800" height="800" loading="lazy" decoding="async">
@@ -274,16 +274,16 @@
                 
       <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16">
         <div class="max-w-[1400px] mx-auto">
-        <div class="flex flex-wrap -m-4 mb-32">
-          <div class="w-full md:w-1/2 p-4">
-            <h1 class="tracking-tight font-heading text-6xl md:text-7xl font-medium max-w-xs text-black">Our Services</h1>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16 sm:mb-20 md:mb-24 lg:mb-32">
+          <div>
+            <h1 class="tracking-tight font-heading text-6xl md:text-7xl font-medium text-black">Our Services</h1>
           </div>
-          <div class="w-full md:w-1/2 p-4">
+          <div>
             <p class="text-gray-900 tracking-tight mb-8 max-w-lg"><span translate="no">Web-Ready</span> builds energy-efficient digital systems that help organizations grow while reducing cost, complexity, and environmental impact. From branding and SEO to accessibility and carbon reduction, <span translate="no">Web-Ready</span> delivers modern solutions that are fast, measurable, and built to scale.</p>
           </div>
         </div>
-        <div class="flex flex-wrap -m-4">
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Technology Solutions</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Web development</a></li>
@@ -292,7 +292,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">In-kind tech grants support</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Digital Responsibility</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Sustainability audits</a></li>
@@ -301,7 +301,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Digital carbon reduction (DRM)</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Digital Marketing</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Search engine optimization (SEO)</a></li>
@@ -309,7 +309,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Google Ads</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Branding &amp; Design</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Logo design</a></li>

--- a/public/news/index.html
+++ b/public/news/index.html
@@ -229,7 +229,7 @@
             </div>
           </nav>
 
-          <section class="px-8 md:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-24 md:pb-32" style="padding-bottom:10rem;">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 sm:pb-24 md:pb-32 lg:pb-40">
             <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6">
               <a href="../index.html" class="hover:text-black transition">Home</a>
               <span class="mx-2" aria-hidden="true">/</span>
@@ -237,7 +237,7 @@
               <span class="mx-2" aria-hidden="true">/</span>
               <span class="text-gray-600">News &amp; Press</span>
             </nav>
-            <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium mb-16 max-w-lg md:max-w-4xl text-black">News, media coverage, and public updates from <span translate="no">Oasis of Change</span></h1>
+            <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium mb-10 sm:mb-14 md:mb-16 max-w-lg md:max-w-4xl text-black">News, media coverage, and public updates from <span translate="no">Oasis of Change</span></h1>
       
             <ul class="news-list border-t border-gray-100">
               <li class="news-row">

--- a/public/tree-planting/index.html
+++ b/public/tree-planting/index.html
@@ -229,41 +229,32 @@
             </div>
           </nav>
 
-          <section class="px-4 md:px-16 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 md:pb-32">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-32">
             <div class="max-w-[1200px] mx-auto">
               <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-8">
                 <a href="../index.html" class="hover:text-black transition">Home</a>
                 <span class="mx-2" aria-hidden="true">/</span>
                 <span class="text-gray-600">Tree Planting &amp; Reforestation</span>
               </nav>
-              <div class="flex flex-wrap -m-4 items-center">
-                <!-- TEXT -->
-                <div class="w-full lg:w-1/2 p-4">
-                  <div class="flex flex-col justify-between gap-10 h-full">
-                    <div>
-                      <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-gray-600 mb-4">Environmental Partnership</p>
-                      <h1 translate="no" class="font-heading tracking-tight text-4xl md:text-5xl lg:text-6xl font-medium mb-6 max-w-lg text-black">Reinvesting into reforestation</h1>
-                      <p class="text-gray-600 text-base md:text-lg leading-8 max-w-lg mb-8">Through our collaboration with <span translate="no">Tree-Nation</span>, a large portion of the funds from our projects are reinvested into global reforestation including supporting endangered species around the world.</p>
-                      
-                    </div>
-                  </div>
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8 items-center">
+                <div>
+                  <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-gray-600 mb-4">Environmental Partnership</p>
+                  <h1 translate="no" class="font-heading tracking-tight text-4xl md:text-5xl lg:text-6xl font-medium mb-6 max-w-lg text-black">Reinvesting into reforestation</h1>
+                  <p class="text-gray-600 text-base md:text-lg leading-8 max-w-lg mb-8">Through our collaboration with <span translate="no">Tree-Nation</span>, a large portion of the funds from our projects are reinvested into global reforestation including supporting endangered species around the world.</p>
                 </div>
-                <!-- IMAGE -->
-                <div class="w-full lg:w-1/2 p-4">
-                  <div class="bg-gray-50 border rounded-[32px] p-6 md:p-8">
-                    <div class="overflow-hidden rounded-[28px] bg-white">
-                      <img src="../images/initiatives/tree-nation-partnership.webp" srcset="../images/initiatives/tree-nation-partnership-400w.webp 400w, ../images/initiatives/tree-nation-partnership-800w.webp 800w, ../images/initiatives/tree-nation-partnership-1200w.webp 1200w, ../images/initiatives/tree-nation-partnership.webp 1568w" sizes="(max-width: 768px) 100vw, 50vw" alt="Tree-Nation reforestation partnership" class="w-full max-h-[220px] md:max-h-[280px] object-cover" width="1568" height="597" loading="lazy">
-                    </div>
+                <div class="bg-gray-50 border rounded-[32px] p-6 md:p-8">
+                  <div class="overflow-hidden rounded-[28px] bg-white">
+                    <img src="../images/initiatives/tree-nation-partnership.webp" srcset="../images/initiatives/tree-nation-partnership-400w.webp 400w, ../images/initiatives/tree-nation-partnership-800w.webp 800w, ../images/initiatives/tree-nation-partnership-1200w.webp 1200w, ../images/initiatives/tree-nation-partnership.webp 1568w" sizes="(max-width: 768px) 100vw, 50vw" alt="Tree-Nation reforestation partnership" class="w-full max-h-[220px] md:max-h-[280px] object-cover" width="1568" height="597" loading="lazy">
                   </div>
                 </div>
               </div>
             </div>
           </section>
 
-          <section class="px-4 md:px-16 py-16 md:py-20">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24">
             <div class="max-w-[1200px] mx-auto">
-              <div class="flex flex-wrap items-center -m-4">
-                <div class="w-full lg:w-7/12 p-4">
+              <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-10 items-center">
+                <div class="lg:col-span-7">
                   <div class="relative max-w-3xl mx-auto">
                     <div class="absolute -top-6 -left-6 w-40 h-40 rounded-[2rem] bg-[#eef4ea]"></div>
                     <div class="absolute -bottom-6 -right-6 w-40 h-40 rounded-[2rem] bg-[#f3f1ea]"></div>
@@ -274,12 +265,12 @@
                     </div>
                   </div>
                 </div>
-                <div class="w-full lg:w-5/12 p-4">
+                <div class="lg:col-span-5">
                   <div class="max-w-xl">
                     <h2 class="tracking-tight font-heading font-semibold text-4xl md:text-5xl leading-tight mb-5 text-black">A custom impact dashboard built for full transparency</h2>
                     <p class="text-gray-600 text-base md:text-lg leading-8 mb-5">We designed and built a custom impact dashboard for <span translate="no">Oasis of Change</span> that makes our tree planting transparent, visual, and easy to explore.</p>
                     <p class="text-gray-600 text-base md:text-lg leading-8 mb-8">The platform highlights real planting data, tracks progress over time, and gives supporters a clear view into the impact behind our work.</p>
-                    <a href="https://impact.oasisofchange.com" target="_blank" rel="noopener noreferrer" class="bg-black h-14 rounded-full px-6 inline-flex items-center justify-center gap-2 hover:bg-gray-800 transition duration-200">
+                    <a href="https://impact.oasisofchange.com" target="_blank" rel="noopener noreferrer" class="bg-black min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 hover:bg-gray-800 transition duration-200 w-full sm:w-auto">
                       <span class="text-white text-sm font-semibold tracking-tight">View the Impact Dashboard</span>
                       <span class="icon-swap">
                         <svg class="icon-swap-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 16 16" fill="none" aria-hidden="true">

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -240,7 +240,7 @@
             </div>
           </nav>
 
-          <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6 px-8 md:px-24">
+          <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6 px-4 sm:px-6 md:px-12 lg:px-24">
             <a href="index.html" class="hover:text-black transition">Home</a>
             <span class="mx-2" aria-hidden="true">/</span>
             <a href="company.html" class="hover:text-black transition">Company</a>
@@ -248,15 +248,15 @@
             <span class="text-gray-600">Our Story</span>
           </nav>
 
-          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-24 px-8 md:px-24">
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/2 p-4">
+          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 px-4 sm:px-6 md:px-12 lg:px-24">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8">
+              <div>
                 <p class="mb-4 tracking-tight">About <span translate="no">Oasis of Change</span></p>
-                <h1 translate="no" class="text-4xl md:text-6xl font-medium tracking-tight mb-16 max-w-xs md:max-w-lg text-black">              Building a more sustainable digital future</h1>
-                <img class="about-hero-image-mobile-hidden rounded-2xl lg:ml-auto object-cover" style="height:419px;" src="images/about/about-page-block-1.webp" alt="Oasis of Change — building sustainable digital experiences" width="353" height="419" loading="lazy">
+                <h1 translate="no" class="text-4xl md:text-6xl font-medium tracking-tight mb-10 sm:mb-12 md:mb-16 md:max-w-lg text-black">Building a more sustainable digital future</h1>
+                <img class="about-hero-image-mobile-hidden rounded-2xl lg:ml-auto object-cover w-full h-[260px] sm:h-[320px] md:h-[380px] lg:h-[419px]" src="images/about/about-page-block-1.webp" alt="Oasis of Change — building sustainable digital experiences" width="353" height="419" loading="lazy">
               </div>
-              <div class="w-full lg:w-1/2 p-4">
-                <img class="rounded-2xl mb-20 object-cover object-right" style="height:516px;" src="images/about/about-page-block-2.webp" srcset="images/about/about-page-block-2-400w.webp 400w, images/about/about-page-block-2-800w.webp 800w, images/about/about-page-block-2.webp 1024w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Founded in 2024" width="1024" height="1024" loading="lazy">
+              <div>
+                <img class="rounded-2xl mb-10 sm:mb-14 md:mb-20 object-cover object-right w-full h-[260px] sm:h-[360px] md:h-[440px] lg:h-[516px]" src="images/about/about-page-block-2.webp" srcset="images/about/about-page-block-2-400w.webp 400w, images/about/about-page-block-2-800w.webp 800w, images/about/about-page-block-2.webp 1024w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Founded in 2024" width="1024" height="1024" loading="lazy">
                 <p class="tracking-tight text-lg max-w-lg"><span translate="no">Oasis of Change</span> was founded to promote digital sustainability through low-carbon, energy-efficient websites and practical innovation that helps people rethink the environmental impact of technology.</p>
               </div>
             </div>
@@ -303,10 +303,10 @@
           </div>
         </div>
       </section>
-      <section class="px-6 md:px-16 lg:px-24 py-24"><div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20"><div class="grid lg:grid-cols-2 gap-12 items-center"><!-- Portrait --><div><div class="bg-white rounded-2xl overflow-hidden"><img class="w-full object-cover" src="images/about/Gabriel-Dalton.webp" srcset="images/about/Gabriel-Dalton-400w.webp 400w, images/about/Gabriel-Dalton.webp 512w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Gabriel Dalton portrait" width="743" height="1075" loading="lazy"></div></div><!-- Bio --><div><p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Founder</p><h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold mb-6">Gabriel Dalton</h2><p class="text-gray-300 text-lg mb-6 max-w-xl">Gabriel Dalton is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. After teaching himself to code at age 10, he began exploring how websites and digital infrastructure impact energy consumption, emissions, and global resources.</p><p class="text-gray-300 text-lg mb-8 max-w-xl">Today his work focuses on building low-carbon websites, improving digital efficiency, and helping organizations reduce the environmental footprint of the internet. His work in sustainable web development earned him the Youth Impact &amp; Innovation Award at the 2025 Vancouver Awards.</p><div class="flex items-center gap-6"><a href="contact.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Get in Touch</a><a href="about.html" class="text-white font-semibold hover:underline" aria-label="Learn more about our story">Learn More →</a></div></div></div></div></section>
-      <section id="our-board" class="px-6 md:px-16 lg:px-24 py-24">
-        <div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20 text-white">
-          <div class="mb-14 text-center">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24"><div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20"><div class="grid lg:grid-cols-2 gap-10 lg:gap-12 items-center"><!-- Portrait --><div><div class="bg-white rounded-2xl overflow-hidden"><img class="w-full object-cover" src="images/about/Gabriel-Dalton.webp" srcset="images/about/Gabriel-Dalton-400w.webp 400w, images/about/Gabriel-Dalton.webp 512w" sizes="(max-width: 1024px) 100vw, 50vw" alt="Gabriel Dalton portrait" width="743" height="1075" loading="lazy"></div></div><!-- Bio --><div><p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Founder</p><h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold mb-6">Gabriel Dalton</h2><p class="text-gray-300 text-lg mb-6 max-w-xl">Gabriel Dalton is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. After teaching himself to code at age 10, he began exploring how websites and digital infrastructure impact energy consumption, emissions, and global resources.</p><p class="text-gray-300 text-lg mb-8 max-w-xl">Today his work focuses on building low-carbon websites, improving digital efficiency, and helping organizations reduce the environmental footprint of the internet. His work in sustainable web development earned him the Youth Impact &amp; Innovation Award at the 2025 Vancouver Awards.</p><div class="flex items-center gap-6"><a href="contact.html" class="bg-white text-black px-6 py-3 rounded-full font-semibold hover:bg-gray-200 transition">Get in Touch</a><a href="about.html" class="text-white font-semibold hover:underline" aria-label="Learn more about our story">Learn More →</a></div></div></div></div></section>
+      <section id="our-board" class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24">
+        <div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20 text-white">
+          <div class="mb-10 sm:mb-14 text-center">
             <p class="text-gray-300 tracking-wide uppercase text-sm mb-4">Leadership</p>
             <h2 class="font-heading tracking-tight text-white text-3xl md:text-4xl font-semibold">Board of Directors</h2>
           </div>
@@ -355,8 +355,8 @@
           </div>
         </div>
       </section>
-      <section class="px-6 md:px-16 lg:px-24 py-24" aria-labelledby="oasis-name-title">
-        <div class="bg-black rounded-2xl p-10 md:p-16 lg:p-20 text-white">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24" aria-labelledby="oasis-name-title">
+        <div class="bg-black rounded-2xl p-8 sm:p-10 md:p-16 lg:p-20 text-white">
           <div class="max-w-3xl mx-auto">
             <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-white/60 mb-6">Our Name</p>
             <h2 id="oasis-name-title" class="font-heading tracking-tight text-3xl md:text-4xl font-semibold mb-4">

--- a/src/pages/annual-report/2024-2025/index.html
+++ b/src/pages/annual-report/2024-2025/index.html
@@ -243,22 +243,22 @@
               <p class="text-xs uppercase tracking-[0.18em] text-gray-600 mb-6">Year in numbers</p>
               <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">675</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">675</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Mangroves planted</p>
                   <p class="text-gray-300 leading-6 text-sm">Mangrove trees funded in Madagascar through Eden Reforestation Projects.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">34,000 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">34,000 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂ offset</p>
                   <p class="text-gray-300 leading-6 text-sm">Estimated lifetime carbon sequestration from the year's mangrove planting.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">1</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">1</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Country reached</p>
                   <p class="text-gray-300 leading-6 text-sm">Madagascar, where restored mangroves protect coastal ecosystems and livelihoods.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">2</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">2</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Initiatives active</p>
                   <p class="text-gray-300 leading-6 text-sm"><span translate="no">Web-Ready</span> sustainable web development and the municipal proclamation campaign.</p>
                 </div>

--- a/src/pages/annual-report/2025-2026/index.html
+++ b/src/pages/annual-report/2025-2026/index.html
@@ -243,22 +243,22 @@
               <p class="text-xs uppercase tracking-[0.18em] text-gray-600 mb-6">Year in numbers</p>
               <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">7,144</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">7,144</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Trees planted this year</p>
                   <p class="text-gray-300 leading-6 text-sm">A 958% year-over-year increase across 14 countries on 6 continents.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">~360,000 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">~360,000 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂ offset, reforestation</p>
                   <p class="text-gray-300 leading-6 text-sm">Estimated lifetime carbon impact of this year's plantings, a 963% year-over-year increase.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">Up to 98%</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">Up to 98%</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">Digital emissions cut</p>
                   <p class="text-gray-300 leading-6 text-sm">Reductions in carbon, energy, and water use achieved on client website projects.</p>
                 </div>
                 <div class="rounded-2xl border border-white/10 p-5 md:p-6 text-white">
-                  <p class="text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">516 kg</p>
+                  <p class="text-2xl sm:text-3xl md:text-4xl font-heading font-medium tracking-tight mb-1">516 kg</p>
                   <p class="text-xs uppercase tracking-[0.14em] text-gray-600 mb-2">CO₂e, hardware recycling</p>
                   <p class="text-gray-300 leading-6 text-sm">Emissions avoided by responsibly recycling two end-of-life laptops to DoD 5220.22-M standards.</p>
                 </div>

--- a/src/pages/blog/index.html
+++ b/src/pages/blog/index.html
@@ -231,15 +231,15 @@
         </div>
       </section>
                 
-      <section class="px-8 md:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 md:pb-20">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 md:pb-20">
         <nav aria-label="Breadcrumb" class="text-sm text-gray-600 max-w-6xl mx-auto mb-8">
           <a href="../index.html" class="hover:text-black transition">Home</a>
           <span class="mx-2" aria-hidden="true">/</span>
           <span class="text-gray-600">Blog</span>
         </nav>
-        <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium text-center mb-14 text-black">Latest from our blog</h1>
-        <div class="flex flex-wrap -m-4 mb-10">
-          <div class="w-full lg:w-1/3 p-4">
+        <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium text-center mb-10 sm:mb-14 text-black">Latest from our blog</h1>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 mb-10">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="ai-ethics-environment.html"><img class="w-full object-cover h-56" src="../images/blog/blog-ai-network-visualization.webp" alt="Abstract visualization of AI network connections" width="416" height="307" loading="lazy"></a>
@@ -255,7 +255,7 @@
               </div>
             </div>
           </div>
-          <div class="w-full lg:w-1/3 p-4">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="sustainable-web-design.html"><img class="w-full object-cover h-56" src="../images/blog/blog-minimal-website-design.webp" alt="Clean minimal website design on a monitor" width="416" height="307" loading="lazy"></a>
@@ -271,7 +271,7 @@
               </div>
             </div>
           </div>
-          <div class="w-full lg:w-1/3 p-4">
+          <div>
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="website-carbon-footprint.html"><img class="w-full object-cover h-56" src="../images/blog/blog-data-center-hardware.webp" alt="Server room with data centre hardware" width="416" height="233" loading="lazy"></a>
@@ -287,7 +287,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="accessible-web-nonprofits.html"><img class="w-full object-cover h-56" src="../images/blog/blog-assistive-technology.webp" alt="Person using assistive technology on a laptop" width="416" height="233" loading="lazy"></a>
@@ -303,7 +303,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="wra-platform-launch.html"><img class="w-full object-cover h-56" src="../images/blog/blog-nonprofit-team-review.webp" alt="Nonprofit team reviewing their website on a shared screen" width="416" height="307" loading="lazy"></a>
@@ -319,7 +319,7 @@
               </div>
             </div>
           </div>
-          <div data-show-more-item class="hidden w-full lg:w-1/3 p-4">
+          <div data-show-more-item class="hidden">
             <div class="bg-white rounded-2xl h-full">
               <div class="relative overflow-hidden rounded-t-2xl">
                 <a href="tree-planting-update.html"><img class="w-full object-cover h-56" src="../images/blog/blog-reforestation-saplings.webp" alt="Newly planted saplings at a reforestation site" width="416" height="233" loading="lazy"></a>

--- a/src/pages/case-studies/breathwave/index.html
+++ b/src/pages/case-studies/breathwave/index.html
@@ -246,8 +246,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 right-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl"><span translate="no">Breathwave</span>, now faster and more accessible than ever</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">We built <span translate="no">Breathwave</span>'s website in 2023 and have kept improving it since. This April, we re-optimized for speed and accessibility, with measurable gains across the board.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl"><span translate="no">Breathwave</span>, now faster and more accessible than ever</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">We built <span translate="no">Breathwave</span>'s website in 2023 and have kept improving it since. This April, we re-optimized for speed and accessibility, with measurable gains across the board.</p>
               </div>
             </div>
           </div>

--- a/src/pages/case-studies/denman-place-mall/index.html
+++ b/src/pages/case-studies/denman-place-mall/index.html
@@ -249,8 +249,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl">Rebuilding the<span translate="no"> Denman Place Mall </span>website around its visitors</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">The majority of visitors arrive on mobile devices within walking distance of the mall. They need store information, hours, and directions. The previous site was not designed with those priorities in mind.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl">Rebuilding the<span translate="no"> Denman Place Mall </span>website around its visitors</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">The majority of visitors arrive on mobile devices within walking distance of the mall. They need store information, hours, and directions. The previous site was not designed with those priorities in mind.</p>
               </div>
             </div>
           </div>
@@ -341,20 +341,20 @@
             </p>
 
             <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Accessible</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Accessible</h3>
                 <p class="tracking-tight text-gray-600">Usable by a wider audience</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Lean</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Lean</h3>
                 <p class="tracking-tight text-gray-600">Reduced page weight throughout</p>
               </div>
-              <div>
-                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium mb-2 text-black">Maintainable</h3>
+              <div class="min-w-0">
+                <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Maintainable</h3>
                 <p class="tracking-tight text-gray-600">Built for long-term stability</p>
               </div>
             </div>
@@ -388,38 +388,32 @@
               </p>
             </div>
 
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Faster
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Page load times improved through the removal of render-blocking resources, image compression, and reduced markup throughout the site.
-                  </p>
-                </div>
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Faster
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Page load times improved through the removal of render-blocking resources, image compression, and reduced markup throughout the site.
+                </p>
               </div>
 
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Clearer
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Store directories, hours, and location information are now positioned consistently. Navigation follows the same structure across every page.
-                  </p>
-                </div>
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Clearer
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Store directories, hours, and location information are now positioned consistently. Navigation follows the same structure across every page.
+                </p>
               </div>
 
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
-                  <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
-                    Lighter
-                  </h3>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    The overall site footprint is significantly smaller, resulting in lower server resource usage, reduced energy consumption per visit, and simplified ongoing maintenance.
-                  </p>
-                </div>
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-8 md:px-8 md:py-10 text-white">
+                <h3 class="font-heading tracking-tight text-3xl md:text-4xl font-medium text-center mb-4 text-white">
+                  Lighter
+                </h3>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  The overall site footprint is significantly smaller, resulting in lower server resource usage, reduced energy consumption per visit, and simplified ongoing maintenance.
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/case-studies/denman-place-mall/index.html
+++ b/src/pages/case-studies/denman-place-mall/index.html
@@ -340,7 +340,7 @@
               <span translate="no">Denman Place Mall</span> is located on one of the busiest pedestrian streets in Vancouver’s West End. It serves a daily-needs function for the surrounding community: groceries, services, dining. The website needed to reflect that purpose: fast to load, easy to navigate, and optimized for mobile screens.
             </p>
 
-            <div class="grid grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
+            <div class="grid grid-cols-2 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
               <div class="min-w-0">
                 <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>

--- a/src/pages/case-studies/denman-place-mall/index.html
+++ b/src/pages/case-studies/denman-place-mall/index.html
@@ -340,7 +340,7 @@
               <span translate="no">Denman Place Mall</span> is located on one of the busiest pedestrian streets in Vancouver’s West End. It serves a daily-needs function for the surrounding community: groceries, services, dining. The website needed to reflect that purpose: fast to load, easy to navigate, and optimized for mobile screens.
             </p>
 
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
+            <div class="grid grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8 mb-10 max-w-3xl mx-auto">
               <div class="min-w-0">
                 <h3 class="font-heading tracking-tight text-2xl sm:text-3xl md:text-4xl font-medium mb-2 text-black">Mobile-first</h3>
                 <p class="tracking-tight text-gray-600">Designed for how visitors arrive</p>

--- a/src/pages/case-studies/mittler-senior-technology/index.html
+++ b/src/pages/case-studies/mittler-senior-technology/index.html
@@ -247,8 +247,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl"><span translate="no">Mittler Senior Technology </span>achieved a 98.2% energy reduction</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">From an F rating to a B rating, this transformation shows how digital sustainability can cut emissions, energy use, and water consumption at scale.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl"><span translate="no">Mittler Senior Technology </span>achieved a 98.2% energy reduction</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">From an F rating to a B rating, this transformation shows how digital sustainability can cut emissions, energy use, and water consumption at scale.</p>
               </div>
             </div>
           </div>
@@ -385,47 +385,41 @@
               </p>
             </div>
       
-            <div class="flex flex-wrap -m-4">
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.2%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Energy reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
-                  </p>
-                </div>
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.2%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Energy reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
+                </p>
               </div>
-      
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Carbon reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
-                  </p>
-                </div>
+
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.1%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Carbon reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
+                </p>
               </div>
-      
-              <div class="w-full lg:w-1/3 p-4">
-                <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
-                  </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Water reduction
-                  </p>
-                  <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
-                    Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
-                  </p>
-                </div>
+
+              <div class="rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
+                <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
+                  98.1%
+                </h3>
+                <p class="text-center tracking-tight text-xl font-semibold mb-4">
+                  Water reduction
+                </p>
+                <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
+                  Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/case-studies/oasis-of-change-website/index.html
+++ b/src/pages/case-studies/oasis-of-change-website/index.html
@@ -248,8 +248,8 @@
               <div class="absolute inset-0 bg-black/70"></div>
               <div class="absolute left-6 bottom-6 md:left-10 md:bottom-10 lg:left-14 lg:bottom-14 z-10">
                 <p class="text-white/80 text-sm md:text-base font-medium tracking-[0.18em] uppercase mb-4">Case Study</p>
-                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium max-w-sm md:max-w-2xl lg:max-w-3xl">How we built the<span translate="no"> Oasis of Change </span>website to be sustainability-first</h1>
-                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 max-w-sm md:max-w-2xl">A transparent, low-impact site that prioritizes performance, accessibility, and clarity—without sacrificing design quality.</p>
+                <h1 class="font-heading tracking-tight text-white text-4xl md:text-5xl lg:text-6xl font-medium md:max-w-2xl lg:max-w-3xl">How we built the<span translate="no"> Oasis of Change </span>website to be sustainability-first</h1>
+                <p class="text-white/85 text-base md:text-lg leading-7 mt-5 md:max-w-2xl">A transparent, low-impact site that prioritizes performance, accessibility, and clarity—without sacrificing design quality.</p>
               </div>
             </div>
           </div>

--- a/src/pages/company.html
+++ b/src/pages/company.html
@@ -235,7 +235,7 @@
             <span class="text-gray-600">Company</span>
           </nav>
 
-          <section class="pb-20 md:pb-28 px-8 md:px-24 mb-12 md:mb-16" aria-labelledby="company-hub-title">
+          <section class="pb-16 sm:pb-20 md:pb-28 px-4 sm:px-6 md:px-12 lg:px-24 mb-12 md:mb-16" aria-labelledby="company-hub-title">
             <div class="max-w-6xl mx-auto">
               <h1 id="company-hub-title" class="font-heading text-3xl sm:text-4xl md:text-5xl font-medium tracking-tight text-black mb-4 max-w-3xl leading-[1.08]">Company</h1>
               <p class="text-base sm:text-lg text-gray-600 leading-7 sm:leading-8 max-w-2xl mb-12 md:mb-14">Who we are, what we stand for, how we are governed, and where to find official updates—everything under Company in one place.</p>

--- a/src/pages/gabriel-dalton.html
+++ b/src/pages/gabriel-dalton.html
@@ -235,7 +235,7 @@
         </div>
       </section>
                 
-      <section class="pt-4 sm:pt-6 md:pt-8 lg:pt-10 pb-24 px-6 md:px-16 lg:px-24">
+      <section class="pt-4 sm:pt-6 md:pt-8 lg:pt-10 pb-16 sm:pb-20 md:pb-24 px-4 sm:px-6 md:px-12 lg:px-24">
         <div class="max-w-6xl mx-auto">
           <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6">
             <a href="index.html" class="hover:text-black transition">Home</a>
@@ -244,8 +244,8 @@
             <span class="mx-2" aria-hidden="true">/</span>
             <span class="text-gray-600">Our Founder</span>
           </nav>
-          <div class="grid lg:grid-cols-2 gap-16 items-center">
-      
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+
           <!-- Text -->
           <div>
             <h1 class="font-heading text-4xl md:text-5xl lg:text-6xl font-medium tracking-tight mb-6 text-black">
@@ -256,7 +256,7 @@
               Gabriel is the founder of <span translate="no">Oasis of Change</span>, a nonprofit focused on digital sustainability and climate-conscious technology. His work explores how the internet impacts energy use, emissions, and global resources.
             </p>
 
-            <a href="#bio" class="bg-black h-14 px-6 rounded-full inline-flex items-center justify-center hover:bg-green-400 transition font-semibold text-white">
+            <a href="#bio" class="bg-black min-h-14 px-6 py-3 rounded-full inline-flex items-center justify-center hover:bg-green-400 transition font-semibold text-white w-full sm:w-auto">
               Read Full Biography
             </a>
           </div>
@@ -270,9 +270,9 @@
         </div>
       </section>
                 
-      <section id="bio" class="py-28 px-6 md:px-16 lg:px-24">
+      <section id="bio" class="py-16 sm:py-20 md:py-24 lg:py-28 px-4 sm:px-6 md:px-12 lg:px-24">
         <div class="max-w-4xl mx-auto">
-      
+
           <h2 class="font-heading text-3xl md:text-4xl font-medium tracking-tight mb-10 text-black">
             About Gabriel Dalton
           </h2>
@@ -304,7 +304,7 @@
         </div>
       </section>
                 
-      <section class="px-4 sm:px-6 md:px-12 py-20 md:py-24 bg-black">
+      <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24 bg-black">
         <div class="max-w-6xl mx-auto">
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
             <div>

--- a/src/pages/get-involved/index.html
+++ b/src/pages/get-involved/index.html
@@ -230,7 +230,7 @@
           </nav>
 
           <!-- GET INVOLVED PAGE -->
-          <section class="px-6 md:px-12 lg:px-24 pt-10 md:pt-16 lg:pt-20 pb-20 md:pb-28 lg:pb-32">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-16 lg:pt-20 pb-16 sm:pb-20 md:pb-28 lg:pb-32">
             <div class="max-w-6xl mx-auto">
               <!-- BREADCRUMB -->
               <nav aria-label="Breadcrumb" class="text-sm text-gray-500 mb-8">

--- a/src/pages/initiatives/web-ready/index.html
+++ b/src/pages/initiatives/web-ready/index.html
@@ -239,11 +239,11 @@
 
       
           <!-- Hero -->
-          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 md:pb-24 lg:pb-32">
-            <div class="flex flex-wrap items-center -m-4">
-              <div class="w-full lg:w-1/2 p-4">
+          <section class="pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-32">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8 items-center">
+              <div>
                 <p class="tracking-tight text-gray-600 font-medium mb-4">Subsidiary Project</p>
-                <h2 class="font-heading tracking-tight text-4xl md:text-6xl font-medium max-w-sm md:max-w-2xl mb-5 leading-[1.02] text-black">
+                <h2 class="font-heading tracking-tight text-4xl md:text-6xl font-medium md:max-w-2xl mb-5 leading-[1.02] text-black">
                   <span translate="no">Web-Ready</span>
                 </h2>
                 <p class="tracking-tight text-gray-600 text-lg leading-8 mb-6 max-w-xl">
@@ -253,14 +253,14 @@
                   It focuses on building websites that are fast, modern, lower-impact, and designed to support real growth for nonprofits, community organizations, and businesses.
                 </p>
                 <div class="flex flex-wrap items-center gap-4">
-                  <a href="https://web-ready.org" target="_blank" rel="noopener noreferrer" class="h-16 rounded-full px-6 py-4 inline-flex items-center justify-center gap-1 border border-gray-200 hover:bg-gray-50 focus:bg-gray-50 focus:ring-4 focus:ring-gray-100 transition duration-200 tracking-tight font-bold text-black">
+                  <a href="https://web-ready.org" target="_blank" rel="noopener noreferrer" class="min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-1 border border-gray-200 hover:bg-gray-50 focus:bg-gray-50 focus:ring-4 focus:ring-gray-100 transition duration-200 tracking-tight font-semibold text-black w-full sm:w-auto">
                     <span>Visit</span>
                     <span translate="no">Web-Ready</span>
                   </a>
                 </div>
               </div>
-      
-              <div class="w-full lg:w-1/2 p-4">
+
+              <div>
                 <div class="lg:ml-auto w-full max-w-lg rounded-[2rem] border border-black/5 bg-white p-6 md:p-8 shadow-sm">
                   <div class="overflow-hidden rounded-2xl bg-[#f3f4f3] ring-1 ring-black/[0.06] flex items-center justify-center p-6 sm:p-8 md:p-10 min-h-[280px] sm:min-h-[360px]">
                     <img class="w-full max-h-[320px] sm:max-h-[380px] object-contain object-center rounded-2xl" src="{{base}}images/logo/web-ready-logo.webp" srcset="{{base}}images/logo/web-ready-logo-400w.webp 400w, {{base}}images/logo/web-ready-logo.webp 500w" sizes="(max-width: 640px) 100vw, 400px" alt="Web-Ready logo" width="800" height="800" loading="lazy" decoding="async">
@@ -274,16 +274,16 @@
                 
       <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16">
         <div class="max-w-[1400px] mx-auto">
-        <div class="flex flex-wrap -m-4 mb-32">
-          <div class="w-full md:w-1/2 p-4">
-            <h1 class="tracking-tight font-heading text-6xl md:text-7xl font-medium max-w-xs text-black">Our Services</h1>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16 sm:mb-20 md:mb-24 lg:mb-32">
+          <div>
+            <h1 class="tracking-tight font-heading text-6xl md:text-7xl font-medium text-black">Our Services</h1>
           </div>
-          <div class="w-full md:w-1/2 p-4">
+          <div>
             <p class="text-gray-900 tracking-tight mb-8 max-w-lg"><span translate="no">Web-Ready</span> builds energy-efficient digital systems that help organizations grow while reducing cost, complexity, and environmental impact. From branding and SEO to accessibility and carbon reduction, <span translate="no">Web-Ready</span> delivers modern solutions that are fast, measurable, and built to scale.</p>
           </div>
         </div>
-        <div class="flex flex-wrap -m-4">
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Technology Solutions</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Web development</a></li>
@@ -292,7 +292,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">In-kind tech grants support</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Digital Responsibility</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Sustainability audits</a></li>
@@ -301,7 +301,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Digital carbon reduction (DRM)</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Digital Marketing</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Search engine optimization (SEO)</a></li>
@@ -309,7 +309,7 @@
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Google Ads</a></li>
             </ul>
           </div>
-          <div class="w-full sm:w-1/2 lg:w-1/4 p-4">
+          <div>
             <p class="font-heading text-gray-800 font-semibold mb-8 tracking-tight">Branding &amp; Design</p>
             <ul class="flex flex-col gap-4">
               <li><a href="#" class="tracking-tight text-black hover:text-opacity-80 font-medium transition duration-200">Logo design</a></li>

--- a/src/pages/news/index.html
+++ b/src/pages/news/index.html
@@ -229,7 +229,7 @@
             </div>
           </nav>
 
-          <section class="px-8 md:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-24 md:pb-32" style="padding-bottom:10rem;">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 sm:pb-24 md:pb-32 lg:pb-40">
             <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-6">
               <a href="{{base}}index.html" class="hover:text-black transition">Home</a>
               <span class="mx-2" aria-hidden="true">/</span>
@@ -237,7 +237,7 @@
               <span class="mx-2" aria-hidden="true">/</span>
               <span class="text-gray-600">News &amp; Press</span>
             </nav>
-            <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium mb-16 max-w-lg md:max-w-4xl text-black">News, media coverage, and public updates from <span translate="no">Oasis of Change</span></h1>
+            <h1 class="font-heading tracking-tight text-4xl md:text-6xl font-medium mb-10 sm:mb-14 md:mb-16 max-w-lg md:max-w-4xl text-black">News, media coverage, and public updates from <span translate="no">Oasis of Change</span></h1>
       
             <ul class="news-list border-t border-gray-100">
               <li class="news-row">

--- a/src/pages/tree-planting/index.html
+++ b/src/pages/tree-planting/index.html
@@ -229,41 +229,32 @@
             </div>
           </nav>
 
-          <section class="px-4 md:px-16 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-20 md:pb-32">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 pt-6 sm:pt-10 md:pt-14 lg:pt-20 pb-16 sm:pb-20 md:pb-24 lg:pb-32">
             <div class="max-w-[1200px] mx-auto">
               <nav aria-label="Breadcrumb" class="text-sm text-gray-600 mb-8">
                 <a href="{{base}}index.html" class="hover:text-black transition">Home</a>
                 <span class="mx-2" aria-hidden="true">/</span>
                 <span class="text-gray-600">Tree Planting &amp; Reforestation</span>
               </nav>
-              <div class="flex flex-wrap -m-4 items-center">
-                <!-- TEXT -->
-                <div class="w-full lg:w-1/2 p-4">
-                  <div class="flex flex-col justify-between gap-10 h-full">
-                    <div>
-                      <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-gray-600 mb-4">Environmental Partnership</p>
-                      <h1 translate="no" class="font-heading tracking-tight text-4xl md:text-5xl lg:text-6xl font-medium mb-6 max-w-lg text-black">Reinvesting into reforestation</h1>
-                      <p class="text-gray-600 text-base md:text-lg leading-8 max-w-lg mb-8">Through our collaboration with <span translate="no">Tree-Nation</span>, a large portion of the funds from our projects are reinvested into global reforestation including supporting endangered species around the world.</p>
-                      
-                    </div>
-                  </div>
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-8 items-center">
+                <div>
+                  <p class="text-[11px] md:text-xs font-semibold tracking-[0.22em] uppercase text-gray-600 mb-4">Environmental Partnership</p>
+                  <h1 translate="no" class="font-heading tracking-tight text-4xl md:text-5xl lg:text-6xl font-medium mb-6 max-w-lg text-black">Reinvesting into reforestation</h1>
+                  <p class="text-gray-600 text-base md:text-lg leading-8 max-w-lg mb-8">Through our collaboration with <span translate="no">Tree-Nation</span>, a large portion of the funds from our projects are reinvested into global reforestation including supporting endangered species around the world.</p>
                 </div>
-                <!-- IMAGE -->
-                <div class="w-full lg:w-1/2 p-4">
-                  <div class="bg-gray-50 border rounded-[32px] p-6 md:p-8">
-                    <div class="overflow-hidden rounded-[28px] bg-white">
-                      <img src="{{base}}images/initiatives/tree-nation-partnership.webp" srcset="{{base}}images/initiatives/tree-nation-partnership-400w.webp 400w, {{base}}images/initiatives/tree-nation-partnership-800w.webp 800w, {{base}}images/initiatives/tree-nation-partnership-1200w.webp 1200w, {{base}}images/initiatives/tree-nation-partnership.webp 1568w" sizes="(max-width: 768px) 100vw, 50vw" alt="Tree-Nation reforestation partnership" class="w-full max-h-[220px] md:max-h-[280px] object-cover" width="1568" height="597" loading="lazy">
-                    </div>
+                <div class="bg-gray-50 border rounded-[32px] p-6 md:p-8">
+                  <div class="overflow-hidden rounded-[28px] bg-white">
+                    <img src="{{base}}images/initiatives/tree-nation-partnership.webp" srcset="{{base}}images/initiatives/tree-nation-partnership-400w.webp 400w, {{base}}images/initiatives/tree-nation-partnership-800w.webp 800w, {{base}}images/initiatives/tree-nation-partnership-1200w.webp 1200w, {{base}}images/initiatives/tree-nation-partnership.webp 1568w" sizes="(max-width: 768px) 100vw, 50vw" alt="Tree-Nation reforestation partnership" class="w-full max-h-[220px] md:max-h-[280px] object-cover" width="1568" height="597" loading="lazy">
                   </div>
                 </div>
               </div>
             </div>
           </section>
 
-          <section class="px-4 md:px-16 py-16 md:py-20">
+          <section class="px-4 sm:px-6 md:px-12 lg:px-24 py-16 sm:py-20 md:py-24">
             <div class="max-w-[1200px] mx-auto">
-              <div class="flex flex-wrap items-center -m-4">
-                <div class="w-full lg:w-7/12 p-4">
+              <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-10 items-center">
+                <div class="lg:col-span-7">
                   <div class="relative max-w-3xl mx-auto">
                     <div class="absolute -top-6 -left-6 w-40 h-40 rounded-[2rem] bg-[#eef4ea]"></div>
                     <div class="absolute -bottom-6 -right-6 w-40 h-40 rounded-[2rem] bg-[#f3f1ea]"></div>
@@ -274,12 +265,12 @@
                     </div>
                   </div>
                 </div>
-                <div class="w-full lg:w-5/12 p-4">
+                <div class="lg:col-span-5">
                   <div class="max-w-xl">
                     <h2 class="tracking-tight font-heading font-semibold text-4xl md:text-5xl leading-tight mb-5 text-black">A custom impact dashboard built for full transparency</h2>
                     <p class="text-gray-600 text-base md:text-lg leading-8 mb-5">We designed and built a custom impact dashboard for <span translate="no">Oasis of Change</span> that makes our tree planting transparent, visual, and easy to explore.</p>
                     <p class="text-gray-600 text-base md:text-lg leading-8 mb-8">The platform highlights real planting data, tracks progress over time, and gives supporters a clear view into the impact behind our work.</p>
-                    <a href="https://impact.oasisofchange.com" target="_blank" rel="noopener noreferrer" class="bg-black h-14 rounded-full px-6 inline-flex items-center justify-center gap-2 hover:bg-gray-800 transition duration-200">
+                    <a href="https://impact.oasisofchange.com" target="_blank" rel="noopener noreferrer" class="bg-black min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 hover:bg-gray-800 transition duration-200 w-full sm:w-auto">
                       <span class="text-white text-sm font-semibold tracking-tight">View the Impact Dashboard</span>
                       <span class="icon-swap">
                         <svg class="icon-swap-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 16 16" fill="none" aria-hidden="true">


### PR DESCRIPTION
On case-studies/denman-place-mall, the 2-col stat grid put "Maintainable"
and "Accessible" h3s at text-3xl (30px) into 132px cells at 320px and
156px cells at 768px (md:grid-cols-4), pushing the page wider than the
viewport. On annual-report/2025-2026, the year-in-numbers tiles did the
same with "~360,000 kg" at text-3xl in a 94px cell at 320px.

- Scale stat headings text-2xl sm:text-3xl md:text-4xl so they fit at
  the narrowest widths.
- Add min-w-0 to grid items so headings respect their cell width.
- Drop max-w-sm cap from the denman hero h1 and lede (caused awkward
  wrap at 414-640px before md:max-w-2xl kicks in).
- Replace the -m-4/p-4 negative-margin flex trick in the denman
  "Scope of work" section with a real grid (same shape as PR #48).