### PR TITLE
Refine text overflow handling in typography styles

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -10,12 +10,12 @@ html, body {
   overflow-x: clip;
 }
 :where(h1, h2, h3, h4, h5, h6) {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   word-break: normal;
-  hyphens: auto;
+  hyphens: manual;
 }
 :where(p, li, blockquote, dt, dd, figcaption, label, a, span) {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 :where(img, svg, video, canvas, picture, iframe) {
   max-width: 100%;
@@ -36,7 +36,7 @@ html, body {
 }
 /* Re-enable in-word breaking for headings only when content actually overflows */
 :where(.font-heading) {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 /* Flex/grid pill rows: prevent fixed-width siblings from pushing siblings off-card.


### PR DESCRIPTION
## Summary
Updated CSS text overflow and hyphenation properties to provide more controlled word breaking behavior across headings and body text elements.

## Key Changes
- Changed `overflow-wrap` from `anywhere` to `break-word` for headings (h1-h6), paragraphs, and other text elements
  - `break-word` allows breaking at word boundaries when needed, while `anywhere` breaks more aggressively within words
- Changed `hyphens` from `auto` to `manual` for headings
  - Disables automatic hyphenation, requiring explicit soft hyphens (`&shy;`) for controlled line breaks
- Applied consistent overflow behavior across `.font-heading` class

## Implementation Details
These changes provide more predictable text wrapping behavior by:
1. Preventing aggressive mid-word breaks that could occur with `overflow-wrap: anywhere`
2. Giving developers explicit control over hyphenation in headings rather than relying on browser heuristics
3. Maintaining responsive text layout while preserving word integrity where possible

https://claude.ai/code/session_01McvExQ3bZL1aKCsM7aL3V5