### PR TITLE
Inline font CSS and lazy-load Google Translate for non-English

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="Page Not Found | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The page you're looking for doesn't exist or has been moved.">
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/about.html
+++ b/public/about.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="About | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/accessibility-statement/index.html
+++ b/public/accessibility-statement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Accessibility Statement | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/annual-report/2024-2025/index.html
+++ b/public/annual-report/2024-2025/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/annual-report/2025-2026/index.html
+++ b/public/annual-report/2025-2026/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/annual-report/index.html
+++ b/public/annual-report/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Annual Reports | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/accessible-web-nonprofits.html
+++ b/public/blog/accessible-web-nonprofits.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/ai-ethics-environment.html
+++ b/public/blog/ai-ethics-environment.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/example-article.html
+++ b/public/blog/example-article.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="New Board Directors | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/sustainable-web-design.html
+++ b/public/blog/sustainable-web-design.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/tree-planting-update.html
+++ b/public/blog/tree-planting-update.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
     <meta name="twitter:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/website-carbon-footprint.html
+++ b/public/blog/website-carbon-footprint.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/blog/wra-platform-launch.html
+++ b/public/blog/wra-platform-launch.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/case-studies/breathwave/index.html
+++ b/public/case-studies/breathwave/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:title" content="Breathwave Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How we rebuilt Breathwave's website on new hosting for dramatic performance and accessibility gains, while preserving the familiar design visitors already know.">
 
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/case-studies/denman-place-mall/index.html
+++ b/public/case-studies/denman-place-mall/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
 
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/case-studies/index.html
+++ b/public/case-studies/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Case Studies | Oasis of Change, Inc.">
     <meta name="twitter:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/case-studies/mittler-senior-technology/index.html
+++ b/public/case-studies/mittler-senior-technology/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/case-studies/oasis-of-change-website/index.html
+++ b/public/case-studies/oasis-of-change-website/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/company.html
+++ b/public/company.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Company | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/contact.html
+++ b/public/contact.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/css/fonts.css
+++ b/public/css/fonts.css
@@ -1,9 +1,0 @@
-/* Plus Jakarta Sans — self-hosted, latin subset (covers 99%+ of English text) */
-@font-face {
-  font-family: 'Plus Jakarta Sans';
-  font-style: normal;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url('../fonts/plus-jakarta-sans-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}

--- a/public/example-annual-report/index.html
+++ b/public/example-annual-report/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/gabriel-dalton.html
+++ b/public/gabriel-dalton.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Gabriel Dalton | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/public/get-involved/index.html
+++ b/public/get-involved/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Get Involved | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
     <link rel="preload" as="font" type="font/woff2" href="fonts/plus-jakarta-sans-latin.woff2" crossorigin>
     <link rel="preload" as="image" type="image/avif" imagesrcset="images/case-studies/nature-sustainability-hero-400w.avif 400w, images/case-studies/nature-sustainability-hero-800w.avif 800w, images/case-studies/nature-sustainability-hero.avif 1172w" imagesizes="(min-width: 1440px) 1400px, (min-width: 1024px) calc(100vw - 12rem), (min-width: 768px) calc(100vw - 6rem), calc(100vw - 2rem)" fetchpriority="high">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/public/initiatives.html
+++ b/public/initiatives.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Initiatives | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/initiatives/sustainable-technology-week/index.html
+++ b/public/initiatives/sustainable-technology-week/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/initiatives/vcasse/index.html
+++ b/public/initiatives/vcasse/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="VCASSE | Oasis of Change, Inc.">
     <meta name="twitter:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/initiatives/web-ready/index.html
+++ b/public/initiatives/web-ready/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/initiatives/wra-platform/index.html
+++ b/public/initiatives/wra-platform/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -543,7 +543,12 @@
       document.documentElement.lang = activeLang;
     }
 
-    loadGoogleTranslate();
+    // Only fetch the Google Translate runtime when the user has actively
+    // chosen a non-English language. English visitors (the default) never
+    // pay the ~123 kB Translate download.
+    if (activeLang !== 'en') {
+      loadGoogleTranslate();
+    }
 
     // Show the translation disclaimer once after the user has just switched
     // to a non-English language. Defer briefly so it appears over content

--- a/public/news/impact-dashboard-launch/index.html
+++ b/public/news/impact-dashboard-launch/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/news/index.html
+++ b/public/news/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="News &amp; Media | Oasis of Change, Inc.">
     <meta name="twitter:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/news/sustainable-technology-week-announcement/index.html
+++ b/public/news/sustainable-technology-week-announcement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Introducing Sustainable Technology Week | Oasis of Change, Inc.">
     <meta name="twitter:description" content="A public initiative focused on digital sustainability, awareness, and practical climate-conscious technology action across Vancouver and beyond.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/news/youth-leadership-recognition/index.html
+++ b/public/news/youth-leadership-recognition/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Youth Leadership Recognition | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Gabriel Dalton is recognized for youth leadership in digital sustainability through the City of Vancouver’s Youth Impact in Innovation Award.">
-    <link rel="stylesheet" href="../../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../../css/site.css">
     <link rel="stylesheet" href="../../css/tailwind/tailwind.min.css?v=2">
     <script src="../../js/site.js" defer></script>

--- a/public/nonprofits.html
+++ b/public/nonprofits.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="For Nonprofits | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Privacy Policy | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/public/sustainability-statement/index.html
+++ b/public/sustainability-statement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainability Statement | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/public/tedx-talk.html
+++ b/public/tedx-talk.html
@@ -34,7 +34,7 @@
     <meta name="twitter:player:width" content="1280">
     <meta name="twitter:player:height" content="720">
 
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/public/tree-planting/index.html
+++ b/public/tree-planting/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="Page Not Found | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The page you're looking for doesn't exist or has been moved.">
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="About | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Discover Oasis of Change's mission to build a more sustainable digital future—our story, founder Gabriel Dalton, and board of directors.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/accessibility-statement/index.html
+++ b/src/pages/accessibility-statement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Accessibility Statement | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change is committed to improving website accessibility for everyone, with ongoing review, testing, and inclusive design practices.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/annual-report/2024-2025/index.html
+++ b/src/pages/annual-report/2024-2025/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2024–2025 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2024–2025 Annual Report covering organizational activities, milestones, and growth during the fiscal year.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/annual-report/2025-2026/index.html
+++ b/src/pages/annual-report/2025-2026/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The Oasis of Change 2025–2026 Annual Report covering organizational progress, key initiatives, impact highlights, and a look ahead.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/annual-report/index.html
+++ b/src/pages/annual-report/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Annual Reports | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Browse Oasis of Change annual reports for transparency and accountability across fiscal years, with new editions added as they are published.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/blog/accessible-web-nonprofits.html
+++ b/src/pages/blog/accessible-web-nonprofits.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Building Accessible Websites: A Guide for Nonprofits | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Web accessibility isn't optional — it's essential. Learn how nonprofits can build inclusive websites that work for everyone, including people with disabilities.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/ai-ethics-environment.html
+++ b/src/pages/blog/ai-ethics-environment.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="AI and the Environment: Balancing Innovation with Responsibility | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Artificial intelligence holds enormous potential for environmental good — but its own carbon cost is growing fast. How do we build AI responsibly?">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/example-article.html
+++ b/src/pages/blog/example-article.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="New Board Directors | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change welcomes Nigel and Catherine to the Board of Directors as we expand digital sustainability, accessibility, and environmental impact work.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/index.html
+++ b/src/pages/blog/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Read the latest from Oasis of Change on digital sustainability, accessibility, transparency, and environmental impact.">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/sustainable-web-design.html
+++ b/src/pages/blog/sustainable-web-design.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="What Is Sustainable Web Design? Principles and Practices | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable web design reduces environmental impact while improving performance and user experience. Learn the core principles behind building greener websites.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/tree-planting-update.html
+++ b/src/pages/blog/tree-planting-update.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="10,000 Trees Planted: Our 2025 Reforestation Update | Oasis of Change, Inc.">
     <meta name="twitter:description" content="A look back at our 2025 tree planting milestone — 10,000 trees planted across reforestation sites, offsetting carbon and restoring ecosystems.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/website-carbon-footprint.html
+++ b/src/pages/blog/website-carbon-footprint.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Why Your Website's Carbon Footprint Matters | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Every website generates carbon emissions. Learn how data centres, page weight, and user traffic contribute to digital pollution — and what you can do about it.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/blog/wra-platform-launch.html
+++ b/src/pages/blog/wra-platform-launch.html
@@ -18,7 +18,7 @@
     <meta name="twitter:title" content="Introducing the WRA Platform: Helping Nonprofits Go Digital Sustainably | Oasis of Change, Inc.">
     <meta name="twitter:description" content="The WRA Platform helps nonprofits build accessible, lower-carbon websites and access digital grants. Here's what it is, why we built it, and how to get involved.">
     <meta property="article:author" content="Gabriel Dalton">
-    <link rel="stylesheet" href="../css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="../css/site.css">
     <link rel="stylesheet" href="../css/tailwind/tailwind.min.css?v=2">
     <script src="../js/site.js" defer></script>

--- a/src/pages/case-studies/breathwave/index.html
+++ b/src/pages/case-studies/breathwave/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:title" content="Breathwave Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How we rebuilt Breathwave's website on new hosting for dramatic performance and accessibility gains, while preserving the familiar design visitors already know.">
 
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/case-studies/denman-place-mall/index.html
+++ b/src/pages/case-studies/denman-place-mall/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:title" content="Denman Place Mall Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How we rebuilt the Denman Place Mall website to improve performance, reduce digital waste, and better serve visitors on mobile devices.">
 
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/case-studies/index.html
+++ b/src/pages/case-studies/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Case Studies | Oasis of Change, Inc.">
     <meta name="twitter:description" content="See real outcomes from sustainable digital projects—how organizations reduced emissions, energy, and water use with Oasis of Change support.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/case-studies/mittler-senior-technology/index.html
+++ b/src/pages/case-studies/mittler-senior-technology/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mittler Senior Technology Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Mittler Senior Technology reached roughly 98% lower energy use and moved from an F to a B digital sustainability rating, cutting emissions and water use at scale with Oasis of Change.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/case-studies/oasis-of-change-website/index.html
+++ b/src/pages/case-studies/oasis-of-change-website/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Oasis of Change Website Case Study | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Case study: how Oasis of Change designed its own website to be fast, accessible, and sustainability-first—built for clarity, transparency, and low-impact performance.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/company.html
+++ b/src/pages/company.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Company | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change—our story, mission, leadership, annual reports, and news.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Contact Oasis of Change for partnerships, media requests, or questions about digital sustainability, accessibility, and impact programs.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/example-annual-report/index.html
+++ b/src/pages/example-annual-report/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="2025–2026 Annual Report | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Summary of Oasis of Change's progress, initiatives, organizational development, and public-facing impact for the 2025–2026 fiscal year.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/gabriel-dalton.html
+++ b/src/pages/gabriel-dalton.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Gabriel Dalton | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Meet Gabriel Dalton, founder of Oasis of Change—a nonprofit focused on digital sustainability, climate-conscious technology, and low-carbon web practices.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/src/pages/get-involved/index.html
+++ b/src/pages/get-involved/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Get Involved | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Volunteer, partner, donate, or collaborate with Oasis of Change to grow digital sustainability and climate-conscious technology worldwide.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -19,7 +19,7 @@
     <meta name="twitter:description" content="Oasis of Change is a nonprofit making the internet more sustainable through low-carbon digital practices, transparent impact reporting, and environmental programs including tree planting.">
     <link rel="preload" as="font" type="font/woff2" href="fonts/plus-jakarta-sans-latin.woff2" crossorigin>
     <link rel="preload" as="image" type="image/avif" imagesrcset="images/case-studies/nature-sustainability-hero-400w.avif 400w, images/case-studies/nature-sustainability-hero-800w.avif 800w, images/case-studies/nature-sustainability-hero.avif 1172w" imagesizes="(min-width: 1440px) 1400px, (min-width: 1024px) calc(100vw - 12rem), (min-width: 768px) calc(100vw - 6rem), calc(100vw - 2rem)" fetchpriority="high">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/src/pages/initiatives.html
+++ b/src/pages/initiatives.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Initiatives | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Explore Oasis of Change initiatives including Web-Ready, VCASSE, Sustainable Technology Week, and platforms that turn mission-driven ideas into measurable impact.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/initiatives/sustainable-technology-week/index.html
+++ b/src/pages/initiatives/sustainable-technology-week/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainable Technology Week | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Sustainable Technology Week brings together education and innovation where technology meets environmental responsibility and climate-conscious design.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/initiatives/vcasse/index.html
+++ b/src/pages/initiatives/vcasse/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="VCASSE | Oasis of Change, Inc.">
     <meta name="twitter:description" content="VCASSE—the Vancouver Centre for AI Safety, Sustainability, and Ethics—advances responsible AI and environmental stewardship through research and collaboration.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/initiatives/web-ready/index.html
+++ b/src/pages/initiatives/web-ready/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Web-Ready is Oasis of Change's sustainable website agency—fast, modern, lower-impact sites for nonprofits, communities, and businesses.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/initiatives/wra-platform/index.html
+++ b/src/pages/initiatives/wra-platform/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Web-Ready Access Platform | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Learn about the Web-Ready Access Platform and how it extends digital access through tools aligned with Oasis of Change's sustainability mission.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/news/impact-dashboard-launch/index.html
+++ b/src/pages/news/impact-dashboard-launch/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Public Impact Dashboard Launch | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Oasis of Change launches a public impact dashboard for transparent tree-planting metrics, geographic reach, and organizational accountability.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/news/index.html
+++ b/src/pages/news/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="News &amp; Media | Oasis of Change, Inc.">
     <meta name="twitter:description" content="News releases, media coverage, and public updates from Oasis of Change—launches, partnerships, Sustainable Technology Week, and transparency tools.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/news/sustainable-technology-week-announcement/index.html
+++ b/src/pages/news/sustainable-technology-week-announcement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Introducing Sustainable Technology Week | Oasis of Change, Inc.">
     <meta name="twitter:description" content="A public initiative focused on digital sustainability, awareness, and practical climate-conscious technology action across Vancouver and beyond.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/news/youth-leadership-recognition/index.html
+++ b/src/pages/news/youth-leadership-recognition/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Youth Leadership Recognition | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Gabriel Dalton is recognized for youth leadership in digital sustainability through the City of Vancouver’s Youth Impact in Innovation Award.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/nonprofits.html
+++ b/src/pages/nonprofits.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="For Nonprofits | Oasis of Change, Inc.">
     <meta name="twitter:description" content="Partner with Oasis of Change to access technology grants, lower-carbon web improvements, and accessibility support through our Web-Ready programme.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/privacy-policy.html
+++ b/src/pages/privacy-policy.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Privacy Policy | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change collects, uses, and protects information submitted through this website, including forms, inquiries, analytics, and communications.">
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <script src="js/site.js" defer></script>

--- a/src/pages/sustainability-statement/index.html
+++ b/src/pages/sustainability-statement/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Sustainability Statement | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change approaches digital sustainability—AWS hosting, renewable energy context, and team operations in British Columbia's clean power grid.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>

--- a/src/pages/tedx-talk.html
+++ b/src/pages/tedx-talk.html
@@ -34,7 +34,7 @@
     <meta name="twitter:player:width" content="1280">
     <meta name="twitter:player:height" content="720">
 
-    <link rel="stylesheet" href="css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="css/site.css">
     <link rel="stylesheet" href="css/tailwind/tailwind.min.css?v=2">
     <link rel="preconnect" href="https://www.youtube-nocookie.com">

--- a/src/pages/tree-planting/index.html
+++ b/src/pages/tree-planting/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tree Planting &amp; Reforestation | Oasis of Change, Inc.">
     <meta name="twitter:description" content="How Oasis of Change reinvests in reforestation and transparent reporting—connecting digital sustainability work to real-world environmental impact.">
-    <link rel="stylesheet" href="{{base}}css/fonts.css">
+    <style>@font-face{font-family:'Plus Jakarta Sans';font-style:normal;font-weight:400 700;font-display:swap;src:url('/fonts/plus-jakarta-sans-latin.woff2') format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}</style>
     <link rel="stylesheet" href="{{base}}css/site.css">
     <link rel="stylesheet" href="{{base}}css/tailwind/tailwind.min.css?v=2">
     <script src="{{base}}js/site.js" defer></script>


### PR DESCRIPTION
## Summary
This PR optimizes page load performance by inlining the Plus Jakarta Sans font declaration directly into HTML `<style>` tags and implementing lazy-loading of Google Translate only when users actively select a non-English language.

## Key Changes

- **Removed external font stylesheet**: Deleted `public/css/fonts.css` and inlined the `@font-face` declaration as a `<style>` tag in all HTML pages. This eliminates an extra HTTP request and allows the font to load with the initial HTML payload.

- **Lazy-load Google Translate**: Modified `public/js/i18n.js` to only fetch the Google Translate runtime (~123 kB) when `activeLang !== 'en'`. English-speaking visitors (the default) no longer incur this download cost.

- **Updated all page templates**: Applied the font inlining change across 40+ HTML files in both `public/` and `src/pages/` directories, ensuring consistent font loading behavior across the entire site.

## Implementation Details

- The inlined `@font-face` rule maintains the same unicode range and font properties as the original external stylesheet
- Google Translate is now conditionally loaded only after a user has explicitly chosen a non-English language, with the translation disclaimer still deferred to appear over content
- All relative paths in inlined styles use absolute paths (e.g., `/fonts/plus-jakarta-sans-latin.woff2`) to work correctly regardless of page depth

This change reduces initial page weight and improves Core Web Vitals for the majority of visitors while maintaining full internationalization support.

https://claude.ai/code/session_01C1X51N1TSXdKkea6u4xCvP