### PR TITLE
Remove query parameters from nonprofit contact form links

### DIFF
--- a/public/nonprofits.html
+++ b/public/nonprofits.html
@@ -257,7 +257,7 @@
                     <p class="text-sm uppercase tracking-[0.18em] text-gray-600 mb-2">Quick start</p>
                     <p class="text-black text-xl font-heading tracking-tight mb-5">Tell us what you need</p>
                     <div class="flex flex-col gap-3">
-                      <a href="contact.html?type=nonprofit" class="w-full inline-flex items-center justify-center rounded-full bg-black px-5 py-3 text-sm font-semibold tracking-tight text-white hover:bg-gray-900 focus:ring-4 focus:ring-gray-200 transition duration-200">
+                      <a href="contact.html" class="w-full inline-flex items-center justify-center rounded-full bg-black px-5 py-3 text-sm font-semibold tracking-tight text-white hover:bg-gray-900 focus:ring-4 focus:ring-gray-200 transition duration-200">
                         Request Nonprofit Support
                       </a>
                       <a href="initiatives/web-ready/" class="w-full inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-5 py-3 text-sm font-semibold tracking-tight text-black hover:bg-gray-50 focus:ring-4 focus:ring-gray-200 transition duration-200">
@@ -299,7 +299,7 @@
                     <li>Get set up with accounts, access, and basics</li>
                     <li>Reduce overhead while improving capacity</li>
                   </ul>
-                  <a href="contact.html?type=nonprofit-grants" class="np-svc-link">
+                  <a href="contact.html" class="np-svc-link">
                     Ask about grants
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
                   </a>
@@ -396,7 +396,7 @@
                   <h2 class="text-white text-2xl md:text-3xl lg:text-4xl font-heading tracking-tight mb-4" style="line-height:1.15">Let's support your mission</h2>
                   <p class="leading-8 mb-7 max-w-2xl" style="color:#9ca3af">Tell us what you're working toward and where you need help. We'll connect you with the right support.</p>
                   <div class="flex flex-col sm:flex-row gap-3">
-                    <a href="contact.html?type=nonprofit" class="np-btn-green w-full sm:w-auto">
+                    <a href="contact.html" class="np-btn-green w-full sm:w-auto">
                       Contact Us
                     </a>
                     <a href="initiatives/wra-platform/" class="np-btn-ghost w-full sm:w-auto">

--- a/src/pages/nonprofits.html
+++ b/src/pages/nonprofits.html
@@ -257,7 +257,7 @@
                     <p class="text-sm uppercase tracking-[0.18em] text-gray-600 mb-2">Quick start</p>
                     <p class="text-black text-xl font-heading tracking-tight mb-5">Tell us what you need</p>
                     <div class="flex flex-col gap-3">
-                      <a href="contact.html?type=nonprofit" class="w-full inline-flex items-center justify-center rounded-full bg-black px-5 py-3 text-sm font-semibold tracking-tight text-white hover:bg-gray-900 focus:ring-4 focus:ring-gray-200 transition duration-200">
+                      <a href="contact.html" class="w-full inline-flex items-center justify-center rounded-full bg-black px-5 py-3 text-sm font-semibold tracking-tight text-white hover:bg-gray-900 focus:ring-4 focus:ring-gray-200 transition duration-200">
                         Request Nonprofit Support
                       </a>
                       <a href="initiatives/web-ready/" class="w-full inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-5 py-3 text-sm font-semibold tracking-tight text-black hover:bg-gray-50 focus:ring-4 focus:ring-gray-200 transition duration-200">
@@ -299,7 +299,7 @@
                     <li>Get set up with accounts, access, and basics</li>
                     <li>Reduce overhead while improving capacity</li>
                   </ul>
-                  <a href="contact.html?type=nonprofit-grants" class="np-svc-link">
+                  <a href="contact.html" class="np-svc-link">
                     Ask about grants
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
                   </a>
@@ -396,7 +396,7 @@
                   <h2 class="text-white text-2xl md:text-3xl lg:text-4xl font-heading tracking-tight mb-4" style="line-height:1.15">Let's support your mission</h2>
                   <p class="leading-8 mb-7 max-w-2xl" style="color:#9ca3af">Tell us what you're working toward and where you need help. We'll connect you with the right support.</p>
                   <div class="flex flex-col sm:flex-row gap-3">
-                    <a href="contact.html?type=nonprofit" class="np-btn-green w-full sm:w-auto">
+                    <a href="contact.html" class="np-btn-green w-full sm:w-auto">
                       Contact Us
                     </a>
                     <a href="initiatives/wra-platform/" class="np-btn-ghost w-full sm:w-auto">


### PR DESCRIPTION
## Summary
Removed query string parameters from contact form links on the nonprofits page. All contact links now point to `contact.html` without type-specific parameters.

## Changes
- Removed `?type=nonprofit` query parameter from "Request Nonprofit Support" button
- Removed `?type=nonprofit-grants` query parameter from "Ask about grants" link
- Removed `?type=nonprofit` query parameter from "Contact Us" button in footer CTA
- Updated both source (`src/pages/nonprofits.html`) and public (`public/nonprofits.html`) versions

## Details
This change simplifies the contact form routing by removing type-specific query parameters. The contact form will now handle nonprofit inquiries through a unified entry point rather than pre-populating form fields via URL parameters.

https://claude.ai/code/session_01UJK6bQpYh8xePr7EBgmbFX