### PR TITLE
Remove lg breakpoint from Mittler CTA button alignment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -649,7 +649,7 @@
           </div>
 
           <!-- CTA -->
-          <div class="flex justify-center lg:justify-start">
+          <div class="flex justify-center">
             <a href="case-studies/mittler-senior-technology/" class="bg-black min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 tracking-tight hover:bg-green-400 transition duration-200 w-full sm:w-auto">
               <span class="text-white text-sm font-semibold">Read the Full Case Study</span>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 16 16" fill="none" aria-hidden="true">

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -649,7 +649,7 @@
           </div>
 
           <!-- CTA -->
-          <div class="flex justify-center lg:justify-start">
+          <div class="flex justify-center">
             <a href="case-studies/mittler-senior-technology/" class="bg-black min-h-14 rounded-full px-6 py-3 inline-flex items-center justify-center gap-2 tracking-tight hover:bg-green-400 transition duration-200 w-full sm:w-auto">
               <span class="text-white text-sm font-semibold">Read the Full Case Study</span>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewbox="0 0 16 16" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary
Simplified the call-to-action button alignment in the Mittler case study section by removing the responsive `lg:justify-start` class, keeping only center alignment across all screen sizes.

## Changes
- Removed `lg:justify-start` Tailwind class from the CTA button container div
- Updated both `public/index.html` and `src/pages/index.html` to maintain consistency
- The button now uses `flex justify-center` for uniform center alignment instead of switching to left alignment on large screens

## Details
This change ensures the "Read the Full Case Study" button maintains consistent center alignment across all viewport sizes, simplifying the layout and providing a more uniform user experience.

https://claude.ai/code/session_011GFrdesPthY7G57yrM6cUe