### PR TITLE
Improve semantic HTML and accessibility in case studies and nonprofits pages

### DIFF
--- a/public/case-studies/mittler-senior-technology/index.html
+++ b/public/case-studies/mittler-senior-technology/index.html
@@ -269,7 +269,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Custom web development</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Custom web development</h2>
                   <p class="text-gray-600 leading-7">For<span translate="no">&nbsp;Mittler Senior Technology</span>, we reworked the website structure and front-end experience to create a cleaner, lighter, and more efficient digital build aligned with both usability and sustainability goals.</p>
                 </div>
               </div>
@@ -283,7 +283,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Accessibility audits</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Accessibility audits</h2>
                   <p class="text-gray-600 leading-7">We reviewed the Mittler site for accessibility-related issues and helped shape improvements that supported clearer navigation, better readability, and a more inclusive experience across devices.</p>
                 </div>
               </div>
@@ -294,7 +294,7 @@
                   <div class="w-16 h-16 mb-7 inline-flex items-center justify-center rounded-full bg-black border border-black">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="w-7 h-7 text-white" viewbox="0 0 16 16"><path d="M8.416.223a.5.5 0 0 0-.832 0l-3 4.5A.5.5 0 0 0 5 5.5h.098L3.076 8.735A.5.5 0 0 0 3.5 9.5h.191l-1.638 3.276a.5.5 0 0 0 .447.724H7V16h2v-2.5h4.5a.5.5 0 0 0 .447-.724L12.31 9.5h.191a.5.5 0 0 0 .424-.765L10.902 5.5H11a.5.5 0 0 0 .416-.777l-3-4.5z"></path></svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Sustainability audits</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Sustainability audits</h2>
                   <p class="text-gray-600 leading-7">We measured the environmental footprint of<span translate="no">&nbsp;Mittler Senior Technology</span>’s website and identified the technical changes that contributed to major reductions in carbon emissions, energy use, and water consumption.</p>
                 </div>
               </div>
@@ -307,7 +307,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Performance optimization</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Performance optimization</h2>
                   <p class="text-gray-600 leading-7">For this case study, we improved load efficiency and reduced unnecessary weight across the site, helping move<span translate="no">&nbsp;Mittler Senior Technology&nbsp;</span>from a much heavier setup to a faster and more technically efficient website.</p>
                 </div>
               </div>
@@ -318,7 +318,7 @@
                   <div class="w-16 h-16 mb-7 inline-flex items-center justify-center rounded-full bg-black border border-black">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="w-7 h-7 text-white" viewbox="0 0 16 16"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm7.5-6.923c-.67.204-1.335.82-1.887 1.855A7.97 7.97 0 0 0 5.145 4H7.5V1.077zM4.09 4a9.267 9.267 0 0 1 .64-1.539 6.7 6.7 0 0 1 .597-.933A7.025 7.025 0 0 0 2.255 4H4.09zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a6.958 6.958 0 0 0-.656 2.5h2.49zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5H4.847zM8.5 5v2.5h2.99a12.495 12.495 0 0 0-.337-2.5H8.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5H4.51zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5H8.5zM5.145 12c.138.386.295.744.468 1.068.552 1.035 1.218 1.65 1.887 1.855V12H5.145zm.182 2.472a6.696 6.696 0 0 1-.597-.933A9.268 9.268 0 0 1 4.09 12H2.255a7.024 7.024 0 0 0 3.072 2.472zM3.82 11a13.652 13.652 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5H3.82zm6.853 3.472A7.024 7.024 0 0 0 13.745 12H11.91a9.27 9.27 0 0 1-.64 1.539 6.688 6.688 0 0 1-.597.933zM8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855.173-.324.33-.682.468-1.068H8.5zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.65 13.65 0 0 1-.312 2.5zm2.802-3.5a6.959 6.959 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5h2.49zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7.024 7.024 0 0 0-3.072-2.472c.218.284.418.598.597.933zM10.855 4a7.966 7.966 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4h2.355z"></path></svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">SEO and digital visibility</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">SEO and digital visibility</h2>
                   <p class="text-gray-600 leading-7">Alongside performance and structural improvements, this work strengthened the technical foundation of the<span translate="no">&nbsp;Mittler Senior Technology&nbsp;</span>site, supporting better discoverability, indexing, and overall digital visibility.</p>
                 </div>
               </div>
@@ -393,12 +393,10 @@
             <div class="flex flex-wrap -m-4">
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.2%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.2%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Energy reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Energy reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
                   </p>
@@ -407,12 +405,10 @@
       
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.1%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Carbon reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Carbon reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
                   </p>
@@ -421,12 +417,10 @@
       
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.1%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Water reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Water reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
                   </p>
@@ -471,32 +465,32 @@
                   </div>
                   <div class="space-y-3">
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">5.31g CO₂</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">5.31g CO₂</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Higher impact</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Energy per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0139 kWh</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Energy per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0139 kWh</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Less efficient</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Water per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">2.95L</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Water per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">2.95L</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Higher resource use</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon rating</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">F rating</p>
-                        <p class="text-sm text-gray-600 mt-1">Among the worst-performing pages measured</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon rating</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">F rating</dd>
+                        <dd class="text-sm text-gray-600 mt-1">Among the worst-performing pages measured</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Needs improvement</span>
                     </div>
                   </div>
@@ -520,32 +514,32 @@
                   </div>
                   <div class="space-y-3">
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.10g CO₂</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.10g CO₂</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.1% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Energy per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0002 kWh</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Energy per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0002 kWh</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.2% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Water per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.06L</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Water per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.06L</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.1% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon rating</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">B rating</p>
-                        <p class="text-sm text-gray-600 mt-1">A major measurable improvement</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon rating</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">B rating</dd>
+                        <dd class="text-sm text-gray-600 mt-1">A major measurable improvement</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">Major improvement</span>
                     </div>
                   </div>
@@ -636,7 +630,7 @@
               </h2>
               <p class="text-gray-600 text-base md:text-lg leading-8 max-w-3xl mx-auto">
                 These figures show how the website’s measured reductions in carbon emissions and energy use translate into broader real-world impact.
-                <a href="#impact-notes" class="align-super text-xs text-gray-300 hover:text-gray-600 transition" aria-label="Jump to notes">1</a>
+                <a href="#impact-notes" class="align-super text-xs text-gray-300 hover:text-gray-600 transition" aria-label="1: Jump to notes">1</a>
               </p>
             </div>
       
@@ -644,92 +638,92 @@
               <!-- CO2 -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">CO₂ equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">CO₂ equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.1% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">6,369.6 kg</p>
-                    <p class="text-sm text-red-700 mt-3">Grade F</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">119.7 kg</p>
-                    <p class="text-sm text-green-700 mt-3">Grade B</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">6,369.6 kg</dd>
+                    <dd class="text-sm text-red-700 mt-3">Grade F</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">119.7 kg</dd>
+                    <dd class="text-sm text-green-700 mt-3">Grade B</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Energy -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Energy consumed</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Energy consumed</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.2% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,620 kWh</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">Higher electricity demand</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">300 kWh</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">Much lighter site build</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,620 kWh</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">Higher electricity demand</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">300 kWh</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">Much lighter site build</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Tea -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Tea-boiling equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Tea-boiling equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.1% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">863,090</p>
-                    <p class="text-sm text-gray-600 mt-3">cups equivalent</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,220</p>
-                    <p class="text-sm text-gray-600 mt-3">cups equivalent</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">863,090</dd>
+                    <dd class="text-sm text-gray-600 mt-3">cups equivalent</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,220</dd>
+                    <dd class="text-sm text-gray-600 mt-3">cups equivalent</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Smartphone charges -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Smartphone charging equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Smartphone charging equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.2% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">1,385,180</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">24,730</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">1,385,180</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">24,730</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</dd>
+                  </dl>
                 </div>
               </div>
       
@@ -737,9 +731,9 @@
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8 lg:col-span-2">
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6 responsive-chip-row">
                   <div>
-                    <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">
+                    <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">
                       Trees needed to absorb the emissions
-                    </p>
+                    </h3>
                     <p class="text-sm text-gray-600 mt-1">At 100,000 annual page views</p>
                   </div>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
@@ -748,11 +742,11 @@
                 </div>
       
                 <div class="grid grid-cols-1 lg:grid-cols-[1fr_auto_1fr] gap-4 lg:gap-6 items-center">
-                  <div class="rounded-2xl bg-white border border-red-200 p-6 text-center">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">290</p>
-                    <p class="text-sm text-gray-600 mt-3">trees needed</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-6 text-center">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">290</dd>
+                    <dd class="text-sm text-gray-600 mt-3">trees needed</dd>
+                  </dl>
       
                   <div class="hidden lg:flex items-center justify-center">
                     <div class="w-12 h-12 rounded-full bg-white border border-black/10 flex items-center justify-center">
@@ -762,11 +756,11 @@
                     </div>
                   </div>
       
-                  <div class="rounded-2xl bg-white border border-green-200 p-6 text-center">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">10</p>
-                    <p class="text-sm text-gray-600 mt-3">trees needed</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-6 text-center">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">10</dd>
+                    <dd class="text-sm text-gray-600 mt-3">trees needed</dd>
+                  </dl>
                 </div>
               </div>
             </div>

--- a/public/nonprofits.html
+++ b/public/nonprofits.html
@@ -307,55 +307,55 @@
 
             <!-- GRANT PROGRAMS -->
             <div class="rounded-[2rem] border border-gray-200 bg-white px-5 py-7 sm:px-8 sm:py-9 md:px-10 md:py-10 mb-5 sm:mb-6">
-              <h3 class="text-black text-2xl md:text-3xl font-heading tracking-tight mb-4" style="line-height:1.15">Grants we help nonprofits unlock</h3>
+              <h2 class="text-black text-2xl md:text-3xl font-heading tracking-tight mb-4" style="line-height:1.15">Grants we help nonprofits unlock</h2>
               <p class="text-gray-600 leading-8 max-w-2xl mb-7">We help nonprofits apply, qualify, and get set up across the platforms they already use.</p>
               <div class="npg-grid">
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-                    <h4 class="npg-title">Google Workspace for Nonprofits</h4>
+                    <h3 class="npg-title">Google Workspace for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Free Google Workspace for up to 2,000 users with 100 TB of pooled storage, custom domain email, Gemini AI, and NotebookLM.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 11 18-7v16L3 13z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/></svg>
-                    <h4 class="npg-title">Google Ad Grants</h4>
+                    <h3 class="npg-title">Google Ad Grants</h3>
                   </div>
                   <p class="npg-body">Up to US$10,000 per month of in-kind Google Search advertising credit for eligible nonprofits.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="13.5" cy="6.5" r="1"/><circle cx="17.5" cy="10.5" r="1"/><circle cx="8.5" cy="7.5" r="1"/><circle cx="6.5" cy="12.5" r="1"/><path d="M12 2a10 10 0 0 0 0 20 4 4 0 0 0 0-8 2 2 0 0 1 0-4 4 4 0 0 0 0-8z"/></svg>
-                    <h4 class="npg-title">Canva for Nonprofits</h4>
+                    <h3 class="npg-title">Canva for Nonprofits</h3>
                   </div>
                   <p class="npg-body">One free team of up to 50 seats with all Canva Pro premium features and Canva Teams collaboration tools.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17.5 19a4.5 4.5 0 0 0 .5-9 6.5 6.5 0 0 0-12.7 1.5A4.5 4.5 0 0 0 6 19z"/></svg>
-                    <h4 class="npg-title">Microsoft for Nonprofits</h4>
+                    <h3 class="npg-title">Microsoft for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Up to 300 free Microsoft 365 Business Basic licenses, plus 75% off Business Premium and other Microsoft cloud products.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9V7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2"/><path d="M3 9h18l-1.5 11a2 2 0 0 1-2 1.7H6.5A2 2 0 0 1 4.5 20z"/><path d="M9 13h6"/></svg>
-                    <h4 class="npg-title">TechSoup</h4>
+                    <h3 class="npg-title">TechSoup</h3>
                   </div>
                   <p class="npg-body">Validates nonprofit status across 236 countries to unlock donated and discounted software from 90+ partners.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/></svg>
-                    <h4 class="npg-title">Atlassian for Nonprofits</h4>
+                    <h3 class="npg-title">Atlassian for Nonprofits</h3>
                   </div>
                   <p class="npg-body">100% off Teamwork Collection (<span translate="no">Jira</span>,<span translate="no">&nbsp;Confluence</span>,<span translate="no">&nbsp;Loom</span>) for up to 25 users, then 75% off Atlassian Cloud above that.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3 10.5 8.5 5 10l5.5 1.5L12 17l1.5-5.5L19 10l-5.5-1.5z"/><path d="M18.5 16.5 17.7 18.7 15.5 19.5 17.7 20.3 18.5 22.5 19.3 20.3 21.5 19.5 19.3 18.7z"/></svg>
-                    <h4 class="npg-title">Claude for Nonprofits</h4>
+                    <h3 class="npg-title">Claude for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Up to 75% off<span translate="no">&nbsp;Claude&nbsp;</span>Team for eligible nonprofits, with built-in integrations for<span translate="no">&nbsp;Blackbaud</span>,<span translate="no">&nbsp;Candid</span>, and<span translate="no">&nbsp;Benevity</span>.</p>
                 </article>

--- a/src/pages/case-studies/mittler-senior-technology/index.html
+++ b/src/pages/case-studies/mittler-senior-technology/index.html
@@ -69,7 +69,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Custom web development</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Custom web development</h2>
                   <p class="text-gray-600 leading-7">For<span translate="no">&nbsp;Mittler Senior Technology</span>, we reworked the website structure and front-end experience to create a cleaner, lighter, and more efficient digital build aligned with both usability and sustainability goals.</p>
                 </div>
               </div>
@@ -83,7 +83,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Accessibility audits</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Accessibility audits</h2>
                   <p class="text-gray-600 leading-7">We reviewed the Mittler site for accessibility-related issues and helped shape improvements that supported clearer navigation, better readability, and a more inclusive experience across devices.</p>
                 </div>
               </div>
@@ -94,7 +94,7 @@
                   <div class="w-16 h-16 mb-7 inline-flex items-center justify-center rounded-full bg-black border border-black">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="w-7 h-7 text-white" viewbox="0 0 16 16"><path d="M8.416.223a.5.5 0 0 0-.832 0l-3 4.5A.5.5 0 0 0 5 5.5h.098L3.076 8.735A.5.5 0 0 0 3.5 9.5h.191l-1.638 3.276a.5.5 0 0 0 .447.724H7V16h2v-2.5h4.5a.5.5 0 0 0 .447-.724L12.31 9.5h.191a.5.5 0 0 0 .424-.765L10.902 5.5H11a.5.5 0 0 0 .416-.777l-3-4.5z"></path></svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Sustainability audits</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Sustainability audits</h2>
                   <p class="text-gray-600 leading-7">We measured the environmental footprint of<span translate="no">&nbsp;Mittler Senior Technology</span>’s website and identified the technical changes that contributed to major reductions in carbon emissions, energy use, and water consumption.</p>
                 </div>
               </div>
@@ -107,7 +107,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
                     </svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">Performance optimization</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">Performance optimization</h2>
                   <p class="text-gray-600 leading-7">For this case study, we improved load efficiency and reduced unnecessary weight across the site, helping move<span translate="no">&nbsp;Mittler Senior Technology&nbsp;</span>from a much heavier setup to a faster and more technically efficient website.</p>
                 </div>
               </div>
@@ -118,7 +118,7 @@
                   <div class="w-16 h-16 mb-7 inline-flex items-center justify-center rounded-full bg-black border border-black">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="w-7 h-7 text-white" viewbox="0 0 16 16"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm7.5-6.923c-.67.204-1.335.82-1.887 1.855A7.97 7.97 0 0 0 5.145 4H7.5V1.077zM4.09 4a9.267 9.267 0 0 1 .64-1.539 6.7 6.7 0 0 1 .597-.933A7.025 7.025 0 0 0 2.255 4H4.09zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a6.958 6.958 0 0 0-.656 2.5h2.49zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5H4.847zM8.5 5v2.5h2.99a12.495 12.495 0 0 0-.337-2.5H8.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5H4.51zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5H8.5zM5.145 12c.138.386.295.744.468 1.068.552 1.035 1.218 1.65 1.887 1.855V12H5.145zm.182 2.472a6.696 6.696 0 0 1-.597-.933A9.268 9.268 0 0 1 4.09 12H2.255a7.024 7.024 0 0 0 3.072 2.472zM3.82 11a13.652 13.652 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5H3.82zm6.853 3.472A7.024 7.024 0 0 0 13.745 12H11.91a9.27 9.27 0 0 1-.64 1.539 6.688 6.688 0 0 1-.597.933zM8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855.173-.324.33-.682.468-1.068H8.5zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.65 13.65 0 0 1-.312 2.5zm2.802-3.5a6.959 6.959 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5h2.49zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7.024 7.024 0 0 0-3.072-2.472c.218.284.418.598.597.933zM10.855 4a7.966 7.966 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4h2.355z"></path></svg>
                   </div>
-                  <p class="tracking-tight text-xl font-semibold mb-4 text-black">SEO and digital visibility</p>
+                  <h2 class="tracking-tight text-xl font-semibold mb-4 text-black">SEO and digital visibility</h2>
                   <p class="text-gray-600 leading-7">Alongside performance and structural improvements, this work strengthened the technical foundation of the<span translate="no">&nbsp;Mittler Senior Technology&nbsp;</span>site, supporting better discoverability, indexing, and overall digital visibility.</p>
                 </div>
               </div>
@@ -193,12 +193,10 @@
             <div class="flex flex-wrap -m-4">
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.2%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.2%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Energy reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Energy reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     Energy use per visit fell from 0.0139 kWh to 0.0002 kWh through a more efficient website build.
                   </p>
@@ -207,12 +205,10 @@
       
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.1%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Carbon reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Carbon reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     CO₂ per page visit dropped from 5.31g to 0.10g, dramatically lowering the website’s environmental impact.
                   </p>
@@ -221,12 +217,10 @@
       
               <div class="w-full lg:w-1/3 p-4">
                 <div class="h-full rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-10 md:px-8 md:py-12 text-white">
-                  <h3 class="font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">
-                    98.1%
+                  <h3>
+                    <span class="block font-heading tracking-tight text-6xl md:text-7xl font-medium text-center mb-6">98.1%</span>
+                    <span class="block text-center tracking-tight text-xl font-semibold mb-4">Water reduction</span>
                   </h3>
-                  <p class="text-center tracking-tight text-xl font-semibold mb-4">
-                    Water reduction
-                  </p>
                   <p class="tracking-tight text-gray-300 text-center max-w-xs mx-auto leading-7">
                     Water consumption per visit decreased from 2.95L to 0.06L, showing the wider resource savings of optimization.
                   </p>
@@ -271,32 +265,32 @@
                   </div>
                   <div class="space-y-3">
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">5.31g CO₂</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">5.31g CO₂</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Higher impact</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Energy per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0139 kWh</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Energy per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0139 kWh</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Less efficient</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Water per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">2.95L</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Water per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">2.95L</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Higher resource use</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-red-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon rating</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">F rating</p>
-                        <p class="text-sm text-gray-600 mt-1">Among the worst-performing pages measured</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon rating</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">F rating</dd>
+                        <dd class="text-sm text-gray-600 mt-1">Among the worst-performing pages measured</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-red-700 bg-red-50 rounded-full px-3 py-1">Needs improvement</span>
                     </div>
                   </div>
@@ -320,32 +314,32 @@
                   </div>
                   <div class="space-y-3">
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.10g CO₂</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.10g CO₂</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.1% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Energy per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0002 kWh</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Energy per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.0002 kWh</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.2% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Water per visit</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.06L</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Water per visit</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">0.06L</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">98.1% lower</span>
                     </div>
                     <div class="rounded-2xl bg-white px-5 py-4 border border-green-100 flex responsive-chip-row items-start justify-between gap-x-4 gap-y-2">
-                      <div>
-                        <p class="text-sm text-gray-600 mb-1">Carbon rating</p>
-                        <p class="text-xl md:text-2xl font-semibold tracking-tight text-black">B rating</p>
-                        <p class="text-sm text-gray-600 mt-1">A major measurable improvement</p>
-                      </div>
+                      <dl>
+                        <dt class="text-sm text-gray-600 mb-1">Carbon rating</dt>
+                        <dd class="text-xl md:text-2xl font-semibold tracking-tight text-black">B rating</dd>
+                        <dd class="text-sm text-gray-600 mt-1">A major measurable improvement</dd>
+                      </dl>
                       <span class="text-xs font-semibold text-green-700 bg-green-50 rounded-full px-3 py-1">Major improvement</span>
                     </div>
                   </div>
@@ -436,7 +430,7 @@
               </h2>
               <p class="text-gray-600 text-base md:text-lg leading-8 max-w-3xl mx-auto">
                 These figures show how the website’s measured reductions in carbon emissions and energy use translate into broader real-world impact.
-                <a href="#impact-notes" class="align-super text-xs text-gray-300 hover:text-gray-600 transition" aria-label="Jump to notes">1</a>
+                <a href="#impact-notes" class="align-super text-xs text-gray-300 hover:text-gray-600 transition" aria-label="1: Jump to notes">1</a>
               </p>
             </div>
       
@@ -444,92 +438,92 @@
               <!-- CO2 -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">CO₂ equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">CO₂ equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.1% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">6,369.6 kg</p>
-                    <p class="text-sm text-red-700 mt-3">Grade F</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">119.7 kg</p>
-                    <p class="text-sm text-green-700 mt-3">Grade B</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">6,369.6 kg</dd>
+                    <dd class="text-sm text-red-700 mt-3">Grade F</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">119.7 kg</dd>
+                    <dd class="text-sm text-green-700 mt-3">Grade B</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Energy -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Energy consumed</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Energy consumed</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.2% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,620 kWh</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">Higher electricity demand</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">300 kWh</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">Much lighter site build</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,620 kWh</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">Higher electricity demand</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">300 kWh</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">Much lighter site build</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Tea -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Tea-boiling equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Tea-boiling equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.1% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">863,090</p>
-                    <p class="text-sm text-gray-600 mt-3">cups equivalent</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,220</p>
-                    <p class="text-sm text-gray-600 mt-3">cups equivalent</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">863,090</dd>
+                    <dd class="text-sm text-gray-600 mt-3">cups equivalent</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">16,220</dd>
+                    <dd class="text-sm text-gray-600 mt-3">cups equivalent</dd>
+                  </dl>
                 </div>
               </div>
       
               <!-- Smartphone charges -->
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6 responsive-chip-row">
-                  <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Smartphone charging equivalent</p>
+                  <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">Smartphone charging equivalent</h3>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
                     98.2% lower
                   </span>
                 </div>
       
                 <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-white border border-red-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">1,385,180</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</p>
-                  </div>
-                  <div class="rounded-2xl bg-white border border-green-200 p-5">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">24,730</p>
-                    <p class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">1,385,180</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</dd>
+                  </dl>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-5">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-2xl md:text-3xl font-semibold tracking-tight text-black leading-tight">24,730</dd>
+                    <dd class="text-sm text-gray-600 mt-3 leading-6">equivalent charges</dd>
+                  </dl>
                 </div>
               </div>
       
@@ -537,9 +531,9 @@
               <div class="rounded-[2rem] bg-[#f7f7f5] border border-black/5 p-6 md:p-7 lg:p-8 lg:col-span-2">
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6 responsive-chip-row">
                   <div>
-                    <p class="text-xl lg:text-2xl font-semibold tracking-tight text-black">
+                    <h3 class="text-xl lg:text-2xl font-semibold tracking-tight text-black">
                       Trees needed to absorb the emissions
-                    </p>
+                    </h3>
                     <p class="text-sm text-gray-600 mt-1">At 100,000 annual page views</p>
                   </div>
                   <span class="inline-flex self-start rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700">
@@ -548,11 +542,11 @@
                 </div>
       
                 <div class="grid grid-cols-1 lg:grid-cols-[1fr_auto_1fr] gap-4 lg:gap-6 items-center">
-                  <div class="rounded-2xl bg-white border border-red-200 p-6 text-center">
-                    <p class="text-sm text-gray-600 mb-2">Before</p>
-                    <p class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">290</p>
-                    <p class="text-sm text-gray-600 mt-3">trees needed</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-red-200 p-6 text-center">
+                    <dt class="text-sm text-gray-600 mb-2">Before</dt>
+                    <dd class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">290</dd>
+                    <dd class="text-sm text-gray-600 mt-3">trees needed</dd>
+                  </dl>
       
                   <div class="hidden lg:flex items-center justify-center">
                     <div class="w-12 h-12 rounded-full bg-white border border-black/10 flex items-center justify-center">
@@ -562,11 +556,11 @@
                     </div>
                   </div>
       
-                  <div class="rounded-2xl bg-white border border-green-200 p-6 text-center">
-                    <p class="text-sm text-gray-600 mb-2">After</p>
-                    <p class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">10</p>
-                    <p class="text-sm text-gray-600 mt-3">trees needed</p>
-                  </div>
+                  <dl class="rounded-2xl bg-white border border-green-200 p-6 text-center">
+                    <dt class="text-sm text-gray-600 mb-2">After</dt>
+                    <dd class="text-4xl md:text-5xl font-semibold tracking-tight text-black leading-none">10</dd>
+                    <dd class="text-sm text-gray-600 mt-3">trees needed</dd>
+                  </dl>
                 </div>
               </div>
             </div>

--- a/src/pages/nonprofits.html
+++ b/src/pages/nonprofits.html
@@ -107,55 +107,55 @@
 
             <!-- GRANT PROGRAMS -->
             <div class="rounded-[2rem] border border-gray-200 bg-white px-5 py-7 sm:px-8 sm:py-9 md:px-10 md:py-10 mb-5 sm:mb-6">
-              <h3 class="text-black text-2xl md:text-3xl font-heading tracking-tight mb-4" style="line-height:1.15">Grants we help nonprofits unlock</h3>
+              <h2 class="text-black text-2xl md:text-3xl font-heading tracking-tight mb-4" style="line-height:1.15">Grants we help nonprofits unlock</h2>
               <p class="text-gray-600 leading-8 max-w-2xl mb-7">We help nonprofits apply, qualify, and get set up across the platforms they already use.</p>
               <div class="npg-grid">
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-                    <h4 class="npg-title">Google Workspace for Nonprofits</h4>
+                    <h3 class="npg-title">Google Workspace for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Free Google Workspace for up to 2,000 users with 100 TB of pooled storage, custom domain email, Gemini AI, and NotebookLM.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 11 18-7v16L3 13z"/><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6"/></svg>
-                    <h4 class="npg-title">Google Ad Grants</h4>
+                    <h3 class="npg-title">Google Ad Grants</h3>
                   </div>
                   <p class="npg-body">Up to US$10,000 per month of in-kind Google Search advertising credit for eligible nonprofits.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="13.5" cy="6.5" r="1"/><circle cx="17.5" cy="10.5" r="1"/><circle cx="8.5" cy="7.5" r="1"/><circle cx="6.5" cy="12.5" r="1"/><path d="M12 2a10 10 0 0 0 0 20 4 4 0 0 0 0-8 2 2 0 0 1 0-4 4 4 0 0 0 0-8z"/></svg>
-                    <h4 class="npg-title">Canva for Nonprofits</h4>
+                    <h3 class="npg-title">Canva for Nonprofits</h3>
                   </div>
                   <p class="npg-body">One free team of up to 50 seats with all Canva Pro premium features and Canva Teams collaboration tools.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17.5 19a4.5 4.5 0 0 0 .5-9 6.5 6.5 0 0 0-12.7 1.5A4.5 4.5 0 0 0 6 19z"/></svg>
-                    <h4 class="npg-title">Microsoft for Nonprofits</h4>
+                    <h3 class="npg-title">Microsoft for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Up to 300 free Microsoft 365 Business Basic licenses, plus 75% off Business Premium and other Microsoft cloud products.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9V7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2"/><path d="M3 9h18l-1.5 11a2 2 0 0 1-2 1.7H6.5A2 2 0 0 1 4.5 20z"/><path d="M9 13h6"/></svg>
-                    <h4 class="npg-title">TechSoup</h4>
+                    <h3 class="npg-title">TechSoup</h3>
                   </div>
                   <p class="npg-body">Validates nonprofit status across 236 countries to unlock donated and discounted software from 90+ partners.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/></svg>
-                    <h4 class="npg-title">Atlassian for Nonprofits</h4>
+                    <h3 class="npg-title">Atlassian for Nonprofits</h3>
                   </div>
                   <p class="npg-body">100% off Teamwork Collection (<span translate="no">Jira</span>,<span translate="no">&nbsp;Confluence</span>,<span translate="no">&nbsp;Loom</span>) for up to 25 users, then 75% off Atlassian Cloud above that.</p>
                 </article>
                 <article class="npg-card">
                   <div class="npg-header">
                     <svg class="npg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3 10.5 8.5 5 10l5.5 1.5L12 17l1.5-5.5L19 10l-5.5-1.5z"/><path d="M18.5 16.5 17.7 18.7 15.5 19.5 17.7 20.3 18.5 22.5 19.3 20.3 21.5 19.5 19.3 18.7z"/></svg>
-                    <h4 class="npg-title">Claude for Nonprofits</h4>
+                    <h3 class="npg-title">Claude for Nonprofits</h3>
                   </div>
                   <p class="npg-body">Up to 75% off<span translate="no">&nbsp;Claude&nbsp;</span>Team for eligible nonprofits, with built-in integrations for<span translate="no">&nbsp;Blackbaud</span>,<span translate="no">&nbsp;Candid</span>, and<span translate="no">&nbsp;Benevity</span>.</p>
                 </article>


### PR DESCRIPTION
## Summary
This PR improves semantic HTML structure and accessibility across the Mittler Senior Technology case study and nonprofits pages by replacing generic `<div>` and `<p>` elements with appropriate semantic HTML elements (`<h2>`, `<h3>`, `<dl>`/`<dt>`/`<dd>`) and enhancing ARIA labels.

## Key Changes

### Semantic HTML Improvements
- **Service section headings**: Changed `<p>` tags to `<h2>` for service titles ("Custom web development", "Accessibility audits", "Sustainability audits", "Performance optimization", "SEO and digital visibility") to establish proper heading hierarchy
- **Statistics headings**: Restructured stat cards to use `<h3>` with nested `<span>` elements instead of separate `<h3>` and `<p>` tags, improving semantic grouping of related content
- **Definition lists**: Converted metric display sections from generic `<div>` + `<p>` combinations to proper `<dl>` (definition list) with `<dt>` (definition term) and `<dd>` (definition data) elements for before/after comparisons and metric pairs
- **Section headings**: Changed "Grants we help nonprofits unlock" from `<h3>` to `<h2>` and grant program titles from `<h4>` to `<h3>` to establish correct heading hierarchy

### Accessibility Enhancements
- **ARIA labels**: Updated footnote link aria-label from "Jump to notes" to "1: Jump to notes" for better context and clarity

## Implementation Details
- Changes applied consistently across both source (`src/pages/`) and public (`public/`) versions of affected files
- All styling classes preserved to maintain visual appearance while improving semantic structure
- Definition lists properly pair labels with values, improving screen reader navigation and semantic meaning
- Heading hierarchy now follows proper nesting conventions (h1 → h2 → h3) for better document structure

https://claude.ai/code/session_01JctBSgr5Fmqse7qRyiXHWZ